### PR TITLE
Added option to parse with pyrosetta with a set of default arguments

### DIFF
--- a/tests/data/pdbs/1bkx.pdb
+++ b/tests/data/pdbs/1bkx.pdb
@@ -1,0 +1,3365 @@
+HEADER    COMPLEX (PHOSPHOTRANSFERASE/ADENOSINE)  01-JUL-97   1BKX              
+TITLE     A BINARY COMPLEX OF THE CATALYTIC SUBUNIT OF CAMP-DEPENDENT PROTEIN   
+TITLE    2 KINASE AND ADENOSINE FURTHER DEFINES CONFORMATIONAL FLEXIBILITY      
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: CAMP-DEPENDENT PROTEIN KINASE;                             
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 FRAGMENT: CATALYTIC SUBUNIT;                                         
+COMPND   5 SYNONYM: CAPK, PKA;                                                  
+COMPND   6 EC: 2.7.1.37;                                                        
+COMPND   7 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: MUS MUSCULUS;                                   
+SOURCE   3 ORGANISM_COMMON: HOUSE MOUSE;                                        
+SOURCE   4 ORGANISM_TAXID: 10090;                                               
+SOURCE   5 EXPRESSION_SYSTEM: ESCHERICHIA COLI;                                 
+SOURCE   6 EXPRESSION_SYSTEM_TAXID: 562                                         
+KEYWDS    CONFORMATIONAL CHANGES, ELECTROSTATIC COMPLEMENTARITY,                
+KEYWDS   2 PHOSPHORYLATION, PROTEIN KINASE, TRANSFERASE, COMPLEX                
+KEYWDS   3 (PHOSPHOTRANSFERASE-ADENOSINE), PHOSPHOTRANSFERASE, COMPLEX          
+KEYWDS   4 (PHOSPHOTRANSFERASE-ADENOSINE) COMPLEX                               
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    N.NARAYANA,S.COX,N.XUONG,L.F.TEN EYCK,S.S.TAYLOR                      
+REVDAT   4   02-AUG-23 1BKX    1       REMARK SEQADV LINK                       
+REVDAT   3   24-FEB-09 1BKX    1       VERSN                                    
+REVDAT   2   01-APR-03 1BKX    1       JRNL                                     
+REVDAT   1   18-MAR-98 1BKX    0                                                
+JRNL        AUTH   N.NARAYANA,S.COX,X.NGUYEN-HUU,L.F.TEN EYCK,S.S.TAYLOR        
+JRNL        TITL   A BINARY COMPLEX OF THE CATALYTIC SUBUNIT OF CAMP-DEPENDENT  
+JRNL        TITL 2 PROTEIN KINASE AND ADENOSINE FURTHER DEFINES CONFORMATIONAL  
+JRNL        TITL 3 FLEXIBILITY.                                                 
+JRNL        REF    STRUCTURE                     V.   5   921 1997              
+JRNL        REFN                   ISSN 0969-2126                               
+JRNL        PMID   9261084                                                      
+JRNL        DOI    10.1016/S0969-2126(97)00246-3                                
+REMARK   1                                                                      
+REMARK   1 REFERENCE 1                                                          
+REMARK   1  AUTH   N.NARAYANA,S.COX,S.SHALTIEL,S.S.TAYLOR,N.XUONG               
+REMARK   1  TITL   CRYSTAL STRUCTURE OF A POLYHISTIDINE-TAGGED RECOMBINANT      
+REMARK   1  TITL 2 CATALYTIC SUBUNIT OF CAMP-DEPENDENT PROTEIN KINASE COMPLEXED 
+REMARK   1  TITL 3 WITH THE PEPTIDE INHIBITOR PKI(5-24) AND ADENOSINE           
+REMARK   1  REF    BIOCHEMISTRY                  V.  36  4438 1997              
+REMARK   1  REFN                   ISSN 0006-2960                               
+REMARK   1 REFERENCE 2                                                          
+REMARK   1  AUTH   J.ZHENG,D.R.KNIGHTON,L.F.TEN EYCK,R.KARLSSON,N.XUONG,        
+REMARK   1  AUTH 2 S.S.TAYLOR,J.M.SOWADSKI                                      
+REMARK   1  TITL   CRYSTAL STRUCTURE OF THE CATALYTIC SUBUNIT OF CAMP-DEPENDENT 
+REMARK   1  TITL 2 PROTEIN KINASE COMPLEXED WITH MGATP AND PEPTIDE INHIBITOR    
+REMARK   1  REF    BIOCHEMISTRY                  V.  32  2154 1993              
+REMARK   1  REFN                   ISSN 0006-2960                               
+REMARK   1 REFERENCE 3                                                          
+REMARK   1  AUTH   F.W.HERBERG,S.M.BELL,S.S.TAYLOR                              
+REMARK   1  TITL   EXPRESSION OF THE CATALYTIC SUBUNIT OF CAMP-DEPENDENT        
+REMARK   1  TITL 2 PROTEIN KINASE IN ESCHERICHIA COLI: MULTIPLE ISOZYMES        
+REMARK   1  TITL 3 REFLECT DIFFERENT PHOSPHORYLATION STATES                     
+REMARK   1  REF    PROTEIN ENG.                  V.   6   771 1993              
+REMARK   1  REFN                   ISSN 0269-2139                               
+REMARK   1 REFERENCE 4                                                          
+REMARK   1  AUTH   D.R.KNIGHTON,J.H.ZHENG,L.F.TEN EYCK,V.A.ASHFORD,N.H.XUONG,   
+REMARK   1  AUTH 2 S.S.TAYLOR,J.M.SOWADSKI                                      
+REMARK   1  TITL   CRYSTAL STRUCTURE OF THE CATALYTIC SUBUNIT OF CYCLIC         
+REMARK   1  TITL 2 ADENOSINE MONOPHOSPHATE-DEPENDENT PROTEIN KINASE             
+REMARK   1  REF    SCIENCE                       V. 253   407 1991              
+REMARK   1  REFN                   ISSN 0036-8075                               
+REMARK   1 REFERENCE 5                                                          
+REMARK   1  AUTH   D.R.KNIGHTON,J.H.ZHENG,L.F.TEN EYCK,N.H.XUONG,S.S.TAYLOR,    
+REMARK   1  AUTH 2 J.M.SOWADSKI                                                 
+REMARK   1  TITL   STRUCTURE OF A PEPTIDE INHIBITOR BOUND TO THE CATALYTIC      
+REMARK   1  TITL 2 SUBUNIT OF CYCLIC ADENOSINE MONOPHOSPHATE-DEPENDENT PROTEIN  
+REMARK   1  TITL 3 KINASE                                                       
+REMARK   1  REF    SCIENCE                       V. 253   414 1991              
+REMARK   1  REFN                   ISSN 0036-8075                               
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.60 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : TNT 5E                                               
+REMARK   3   AUTHORS     : TRONRUD,TEN EYCK,MATTHEWS                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.60                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 10.00                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.000                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 86.0                           
+REMARK   3   NUMBER OF REFLECTIONS             : 10720                          
+REMARK   3                                                                      
+REMARK   3  USING DATA ABOVE SIGMA CUTOFF.                                      
+REMARK   3   CROSS-VALIDATION METHOD          : NULL                            
+REMARK   3   FREE R VALUE TEST SET SELECTION  : NULL                            
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.219                           
+REMARK   3   R VALUE            (WORKING SET) : 0.205                           
+REMARK   3   FREE R VALUE                     : 0.340                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 10.000                          
+REMARK   3   FREE R VALUE TEST SET COUNT      : NULL                            
+REMARK   3                                                                      
+REMARK   3  USING ALL DATA, NO SIGMA CUTOFF.                                    
+REMARK   3   R VALUE   (WORKING + TEST SET, NO CUTOFF) : 0.2190                 
+REMARK   3   R VALUE          (WORKING SET, NO CUTOFF) : 0.2050                 
+REMARK   3   FREE R VALUE                  (NO CUTOFF) : 0.340                  
+REMARK   3   FREE R VALUE TEST SET SIZE (%, NO CUTOFF) : 10.00                  
+REMARK   3   FREE R VALUE TEST SET COUNT   (NO CUTOFF) : NULL                   
+REMARK   3   TOTAL NUMBER OF REFLECTIONS   (NO CUTOFF) : 10720                  
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 2801                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 19                                      
+REMARK   3   SOLVENT ATOMS            : 12                                      
+REMARK   3                                                                      
+REMARK   3  WILSON B VALUE (FROM FCALC, A**2) : 45.000                          
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.    RMS    WEIGHT  COUNT           
+REMARK   3   BOND LENGTHS                 (A) : 0.020 ; 1.900 ; 2894            
+REMARK   3   BOND ANGLES            (DEGREES) : 1.700 ; 12.000; 3891            
+REMARK   3   TORSION ANGLES         (DEGREES) : 20.200; 0.000 ; 1700            
+REMARK   3   PSEUDOROTATION ANGLES  (DEGREES) : NULL  ; NULL  ; NULL            
+REMARK   3   TRIGONAL CARBON PLANES       (A) : 0.010 ; 5.000 ; 75              
+REMARK   3   GENERAL PLANES               (A) : 0.020 ; 14.000; 407             
+REMARK   3   ISOTROPIC THERMAL FACTORS (A**2) : 12.800; 0.900 ; 2859            
+REMARK   3   NON-BONDED CONTACTS          (A) : 0.030 ; 30.000; 100             
+REMARK   3                                                                      
+REMARK   3  INCORRECT CHIRAL-CENTERS (COUNT) : NULL                             
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED : NULL                                                 
+REMARK   3   KSOL        : 0.70                                                 
+REMARK   3   BSOL        : 654.5                                                
+REMARK   3                                                                      
+REMARK   3  RESTRAINT LIBRARIES.                                                
+REMARK   3   STEREOCHEMISTRY : STANDARD TNT GEOMETRY LIBRARY FILES              
+REMARK   3   ISOTROPIC THERMAL FACTOR RESTRAINTS : YES                          
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1BKX COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
+REMARK 100 THE DEPOSITION ID IS D_1000171874.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 13-SEP-94                          
+REMARK 200  TEMPERATURE           (KELVIN) : 277                                
+REMARK 200  PH                             : 8.0                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : N                                  
+REMARK 200  RADIATION SOURCE               : ROTATING ANODE                     
+REMARK 200  BEAMLINE                       : NULL                               
+REMARK 200  X-RAY GENERATOR MODEL          : RIGAKU RUH2R                       
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.5418                             
+REMARK 200  MONOCHROMATOR                  : GRAPHITE(002)                      
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : AREA DETECTOR                      
+REMARK 200  DETECTOR MANUFACTURER          : XUONG-HAMLIN MULTIWIRE             
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : UCSD                               
+REMARK 200  DATA SCALING SOFTWARE          : UCSD                               
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 10720                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.600                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 30.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 0.000                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 86.0                               
+REMARK 200  DATA REDUNDANCY                : 2.500                              
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : 0.09400                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 8.5000                             
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.60                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.70                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 74.0                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : 1.50                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : 0.20000                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 1.000                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: NULL                                           
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: X-PLOR                                                
+REMARK 200 STARTING MODEL: PDB ENTRY 1CTP                                       
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 51.00                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.60                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: THE RC.ADE BINARY COMPLEX CRYSTALS       
+REMARK 280  WERE GROWN AT 4 C BY THE HANGING-DROP VAPOR DIFFUSION METHOD.       
+REMARK 280  THE CRYSTALLIZATION DROPLET CONTAINED PROTEIN (0.5 MM),             
+REMARK 280  ADENOSINE (3 MM) AND 2-METHYL-2,4-PENTANEDIOL (MPD; 4%) IN 100      
+REMARK 280  MM BICINE BUFFER AT PH 8.0. THE CRYSTALLIZATION WELL SOLUTION       
+REMARK 280  WAS MADE UP OF 15% MPD AND 100 MM AMMONIUM-SULFATE IN BICINE        
+REMARK 280  BUFFER (100 MM; PH 8.0). THE CRYSTALS GREW OVER THE COURSE OF 8-    
+REMARK 280  12 WEEKS TO A FINAL SIZE OF 0.2 X 0.3 X 0.5 MM3., VAPOR             
+REMARK 280  DIFFUSION - HANGING DROP, TEMPERATURE 277K, VAPOR DIFFUSION,        
+REMARK 280  HANGING DROP                                                        
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 21 21 21                       
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X+1/2,-Y,Z+1/2                                         
+REMARK 290       3555   -X,Y+1/2,-Z+1/2                                         
+REMARK 290       4555   X+1/2,-Y+1/2,-Z                                         
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000       27.92500            
+REMARK 290   SMTRY2   2  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000       49.36000            
+REMARK 290   SMTRY1   3 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   3  0.000000  1.000000  0.000000       36.61500            
+REMARK 290   SMTRY3   3  0.000000  0.000000 -1.000000       49.36000            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       27.92500            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000       36.61500            
+REMARK 290   SMTRY3   4  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     GLY A     1                                                      
+REMARK 465     ASN A     2                                                      
+REMARK 465     ALA A     3                                                      
+REMARK 465     ALA A     4                                                      
+REMARK 465     ALA A     5                                                      
+REMARK 465     ALA A     6                                                      
+REMARK 465     LYS A     7                                                      
+REMARK 465     LYS A     8                                                      
+REMARK 465     GLY A     9                                                      
+REMARK 465     SEP A    10                                                      
+REMARK 465     GLU A    11                                                      
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND LENGTHS                                      
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,2(A3,1X,A1,I4,A1,1X,A4,3X),1X,F6.3)               
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   RES CSSEQI ATM2   DEVIATION                     
+REMARK 500    GLU A  13   CD    GLU A  13   OE2     0.089                       
+REMARK 500    GLU A  17   CD    GLU A  17   OE2     0.082                       
+REMARK 500    GLU A  24   CD    GLU A  24   OE2     0.080                       
+REMARK 500    GLU A  31   CD    GLU A  31   OE1     0.110                       
+REMARK 500    GLU A  64   CD    GLU A  64   OE2     0.066                       
+REMARK 500    GLU A  86   CD    GLU A  86   OE2     0.082                       
+REMARK 500    GLU A  91   CD    GLU A  91   OE2     0.097                       
+REMARK 500    GLU A 127   CD    GLU A 127   OE2     0.075                       
+REMARK 500    GLU A 140   CD    GLU A 140   OE1    -0.071                       
+REMARK 500    GLU A 140   CD    GLU A 140   OE2     0.082                       
+REMARK 500    GLU A 155   CD    GLU A 155   OE2     0.081                       
+REMARK 500    GLU A 203   CD    GLU A 203   OE2     0.075                       
+REMARK 500    GLU A 248   CD    GLU A 248   OE2     0.080                       
+REMARK 500    GLU A 311   CD    GLU A 311   OE2     0.069                       
+REMARK 500    GLU A 341   CD    GLU A 341   OE2     0.074                       
+REMARK 500    GLU A 346   CD    GLU A 346   OE2     0.071                       
+REMARK 500    GLU A 349   CD    GLU A 349   OE2     0.093                       
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    ASP A  41   CB  -  CG  -  OD2 ANGL. DEV. =  -6.0 DEGREES          
+REMARK 500    ASP A  44   CB  -  CG  -  OD2 ANGL. DEV. =  -6.5 DEGREES          
+REMARK 500    ASP A  75   CB  -  CG  -  OD1 ANGL. DEV. =   6.1 DEGREES          
+REMARK 500    ASP A  75   CB  -  CG  -  OD2 ANGL. DEV. =  -6.2 DEGREES          
+REMARK 500    ASP A 166   CB  -  CG  -  OD2 ANGL. DEV. =  -5.9 DEGREES          
+REMARK 500    ASP A 175   CB  -  CG  -  OD2 ANGL. DEV. =  -7.1 DEGREES          
+REMARK 500    ASP A 184   CB  -  CG  -  OD2 ANGL. DEV. =  -5.5 DEGREES          
+REMARK 500    ASP A 241   CB  -  CG  -  OD2 ANGL. DEV. =  -5.7 DEGREES          
+REMARK 500    ASP A 264   CB  -  CG  -  OD1 ANGL. DEV. =   6.0 DEGREES          
+REMARK 500    ASP A 264   CB  -  CG  -  OD2 ANGL. DEV. =  -6.3 DEGREES          
+REMARK 500    ASP A 290   CB  -  CG  -  OD1 ANGL. DEV. =   6.6 DEGREES          
+REMARK 500    ASP A 290   CB  -  CG  -  OD2 ANGL. DEV. =  -7.4 DEGREES          
+REMARK 500    ASP A 301   CB  -  CG  -  OD1 ANGL. DEV. =   5.6 DEGREES          
+REMARK 500    ASP A 301   CB  -  CG  -  OD2 ANGL. DEV. =  -5.4 DEGREES          
+REMARK 500    PRO A 316   C   -  N   -  CD  ANGL. DEV. = -29.9 DEGREES          
+REMARK 500    ASP A 323   CB  -  CG  -  OD2 ANGL. DEV. =  -6.2 DEGREES          
+REMARK 500    ASP A 328   CB  -  CG  -  OD2 ANGL. DEV. =  -7.8 DEGREES          
+REMARK 500    ASP A 329   CB  -  CG  -  OD1 ANGL. DEV. =   5.7 DEGREES          
+REMARK 500    ASP A 329   CB  -  CG  -  OD2 ANGL. DEV. =  -8.9 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    GLU A  13      -80.12    -96.92                                   
+REMARK 500    VAL A  15       47.15    -75.18                                   
+REMARK 500    LYS A  16      -23.38   -158.75                                   
+REMARK 500    PHE A  18      -77.25    -60.87                                   
+REMARK 500    LEU A  19      -36.98    -33.44                                   
+REMARK 500    LYS A  28      -82.05    -42.03                                   
+REMARK 500    GLU A  31       47.88    -85.71                                   
+REMARK 500    THR A  32       91.96    158.04                                   
+REMARK 500    GLN A  35     -130.36   -114.96                                   
+REMARK 500    ASN A  36      120.50    -20.39                                   
+REMARK 500    ILE A  46      -60.86    -97.54                                   
+REMARK 500    ARG A  56      139.12   -173.57                                   
+REMARK 500    GLU A  64      -97.95    -51.60                                   
+REMARK 500    LYS A  83        7.22     41.70                                   
+REMARK 500    GLN A  84        7.26    -45.65                                   
+REMARK 500    HIS A  87      -74.26    -70.70                                   
+REMARK 500    THR A  88      -16.13    -31.87                                   
+REMARK 500    ASN A  99      114.88   -164.90                                   
+REMARK 500    PHE A 100      148.00   -179.54                                   
+REMARK 500    ASN A 113      -63.14     14.58                                   
+REMARK 500    PHE A 129      -33.58    -34.46                                   
+REMARK 500    GLU A 140      -39.65    -24.33                                   
+REMARK 500    HIS A 142      -70.16    -41.62                                   
+REMARK 500    LEU A 157      -77.64    -51.76                                   
+REMARK 500    HIS A 158      -34.94    -28.88                                   
+REMARK 500    ARG A 165       -9.22     69.20                                   
+REMARK 500    GLN A 176       -2.98    -59.08                                   
+REMARK 500    ASP A 184       75.16     61.99                                   
+REMARK 500    ALA A 188      175.69    -41.89                                   
+REMARK 500    LYS A 189      109.65    178.05                                   
+REMARK 500    SER A 212       71.01     71.77                                   
+REMARK 500    LYS A 217      -36.31    -30.86                                   
+REMARK 500    TYR A 235      157.18    -38.66                                   
+REMARK 500    PHE A 239      129.19   -173.84                                   
+REMARK 500    SER A 262      170.75    -53.94                                   
+REMARK 500    LEU A 269      -85.49    -30.63                                   
+REMARK 500    ARG A 270       -3.58    -48.64                                   
+REMARK 500    LEU A 273       44.80    -60.06                                   
+REMARK 500    VAL A 275        2.55    -59.99                                   
+REMARK 500    THR A 278       44.26    -79.23                                   
+REMARK 500    LYS A 279       53.97    167.86                                   
+REMARK 500    TRP A 296      -33.97    -35.75                                   
+REMARK 500    GLN A 307        1.61    -60.23                                   
+REMARK 500    ASN A 326        2.73    -63.98                                   
+REMARK 500    ILE A 335       66.67   -104.64                                   
+REMARK 500    VAL A 337       60.57   -153.76                                   
+REMARK 500    SEP A 338      166.41    -22.10                                   
+REMARK 500    GLU A 341       91.11    -55.12                                   
+REMARK 500    CYS A 343       29.37     48.77                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 610                                                                      
+REMARK 610 MISSING HETEROATOM                                                   
+REMARK 610 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
+REMARK 610 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
+REMARK 610 I=INSERTION CODE):                                                   
+REMARK 610   M RES C SSEQI                                                      
+REMARK 610       A A  351                                                       
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE A A 351                   
+DBREF  1BKX A    1   350  UNP    P05132   KAPCA_MOUSE      1    350             
+SEQADV 1BKX SEP A   10  UNP  P05132    SER    10 CONFLICT                       
+SEQADV 1BKX TPO A  197  UNP  P05132    THR   197 MODIFIED RESIDUE               
+SEQADV 1BKX SEP A  338  UNP  P05132    SER   338 MODIFIED RESIDUE               
+SEQRES   1 A  350  GLY ASN ALA ALA ALA ALA LYS LYS GLY SEP GLU GLN GLU          
+SEQRES   2 A  350  SER VAL LYS GLU PHE LEU ALA LYS ALA LYS GLU ASP PHE          
+SEQRES   3 A  350  LEU LYS LYS TRP GLU THR PRO SER GLN ASN THR ALA GLN          
+SEQRES   4 A  350  LEU ASP GLN PHE ASP ARG ILE LYS THR LEU GLY THR GLY          
+SEQRES   5 A  350  SER PHE GLY ARG VAL MET LEU VAL LYS HIS LYS GLU SER          
+SEQRES   6 A  350  GLY ASN HIS TYR ALA MET LYS ILE LEU ASP LYS GLN LYS          
+SEQRES   7 A  350  VAL VAL LYS LEU LYS GLN ILE GLU HIS THR LEU ASN GLU          
+SEQRES   8 A  350  LYS ARG ILE LEU GLN ALA VAL ASN PHE PRO PHE LEU VAL          
+SEQRES   9 A  350  LYS LEU GLU PHE SER PHE LYS ASP ASN SER ASN LEU TYR          
+SEQRES  10 A  350  MET VAL MET GLU TYR VAL ALA GLY GLY GLU MET PHE SER          
+SEQRES  11 A  350  HIS LEU ARG ARG ILE GLY ARG PHE SER GLU PRO HIS ALA          
+SEQRES  12 A  350  ARG PHE TYR ALA ALA GLN ILE VAL LEU THR PHE GLU TYR          
+SEQRES  13 A  350  LEU HIS SER LEU ASP LEU ILE TYR ARG ASP LEU LYS PRO          
+SEQRES  14 A  350  GLU ASN LEU LEU ILE ASP GLN GLN GLY TYR ILE GLN VAL          
+SEQRES  15 A  350  THR ASP PHE GLY PHE ALA LYS ARG VAL LYS GLY ARG THR          
+SEQRES  16 A  350  TRP TPO LEU CYS GLY THR PRO GLU TYR LEU ALA PRO GLU          
+SEQRES  17 A  350  ILE ILE LEU SER LYS GLY TYR ASN LYS ALA VAL ASP TRP          
+SEQRES  18 A  350  TRP ALA LEU GLY VAL LEU ILE TYR GLU MET ALA ALA GLY          
+SEQRES  19 A  350  TYR PRO PRO PHE PHE ALA ASP GLN PRO ILE GLN ILE TYR          
+SEQRES  20 A  350  GLU LYS ILE VAL SER GLY LYS VAL ARG PHE PRO SER HIS          
+SEQRES  21 A  350  PHE SER SER ASP LEU LYS ASP LEU LEU ARG ASN LEU LEU          
+SEQRES  22 A  350  GLN VAL ASP LEU THR LYS ARG PHE GLY ASN LEU LYS ASN          
+SEQRES  23 A  350  GLY VAL ASN ASP ILE LYS ASN HIS LYS TRP PHE ALA THR          
+SEQRES  24 A  350  THR ASP TRP ILE ALA ILE TYR GLN ARG LYS VAL GLU ALA          
+SEQRES  25 A  350  PRO PHE ILE PRO LYS PHE LYS GLY PRO GLY ASP THR SER          
+SEQRES  26 A  350  ASN PHE ASP ASP TYR GLU GLU GLU GLU ILE ARG VAL SEP          
+SEQRES  27 A  350  ILE ASN GLU LYS CYS GLY LYS GLU PHE THR GLU PHE              
+MODRES 1BKX TPO A  197  THR  PHOSPHOTHREONINE                                   
+MODRES 1BKX SEP A  338  SER  PHOSPHOSERINE                                      
+HET    TPO  A 197      11                                                       
+HET    SEP  A 338      10                                                       
+HET      A  A 351      19                                                       
+HETNAM     TPO PHOSPHOTHREONINE                                                 
+HETNAM     SEP PHOSPHOSERINE                                                    
+HETNAM       A ADENOSINE-5'-MONOPHOSPHATE                                       
+HETSYN     TPO PHOSPHONOTHREONINE                                               
+HETSYN     SEP PHOSPHONOSERINE                                                  
+FORMUL   1  TPO    C4 H10 N O6 P                                                
+FORMUL   1  SEP    C3 H8 N O6 P                                                 
+FORMUL   2    A    C10 H14 N5 O7 P                                              
+FORMUL   3  HOH   *12(H2 O)                                                     
+HELIX    1   A GLU A   13  GLU A   31  1                                  19    
+HELIX    2  AB LEU A   40  GLN A   42  5                                   3    
+HELIX    3   B LYS A   76  LEU A   82  1                                   7    
+HELIX    4   C GLN A   84  ALA A   97  1                                  14    
+HELIX    5   D MET A  128  ILE A  135  1                                   8    
+HELIX    6   E GLU A  140  LEU A  160  1                                  21    
+HELIX    7 EF0 PRO A  169  ASN A  171  5                                   3    
+HELIX    8 EF1 PHE A  185  PHE A  187  5                                   3    
+HELIX    9 EF2 PRO A  202  TYR A  204  5                                   3    
+HELIX   10  EF PRO A  207  LEU A  211  1                                   5    
+HELIX   11   F LYS A  217  ALA A  233  1                                  17    
+HELIX   12   G PRO A  243  SER A  252  1                                  10    
+HELIX   13   H SER A  263  LEU A  273  1                                  11    
+HELIX   14  HI LEU A  277  LYS A  279  5                                   3    
+HELIX   15   I VAL A  288  ASN A  293  5                                   6    
+HELIX   16  IJ LYS A  295  PHE A  297  5                                   3    
+HELIX   17   J TRP A  302  GLN A  307  1                                   6    
+SHEET    1   A 5 PHE A  43  GLY A  52  0                                        
+SHEET    2   A 5 GLY A  55  HIS A  62 -1  N  VAL A  57   O  GLY A  50           
+SHEET    3   A 5 ASN A  67  ASP A  75 -1  N  MET A  71   O  MET A  58           
+SHEET    4   A 5 ASN A 115  MET A 120 -1  N  MET A 120   O  ALA A  70           
+SHEET    5   A 5 LEU A 106  ASP A 112 -1  N  ASP A 112   O  ASN A 115           
+SHEET    1   B 2 ASP A 161  ILE A 163  0                                        
+SHEET    2   B 2 LEU A 172  ASP A 175 -1                                        
+SHEET    1   C 2 TYR A 179  THR A 183  0                                        
+SHEET    2   C 2 ALA A 188  LYS A 192 -1                                        
+LINK         C   TRP A 196                 N   TPO A 197     1555   1555  1.31  
+LINK         C   TPO A 197                 N   LEU A 198     1555   1555  1.31  
+LINK         C   VAL A 337                 N   SEP A 338     1555   1555  1.32  
+LINK         C   SEP A 338                 N   ILE A 339     1555   1555  1.31  
+SITE     1 AC1 11 LEU A  49  GLY A  50  VAL A  57  VAL A 104                    
+SITE     2 AC1 11 GLU A 121  TYR A 122  VAL A 123  GLU A 170                    
+SITE     3 AC1 11 LEU A 173  THR A 183  PHE A 327                               
+CRYST1   55.850   73.230   98.720  90.00  90.00  90.00 P 21 21 21    4          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.017905  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  0.013656  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.010130        0.00000                         
+ATOM      1  N   GLN A  12      17.825  60.742  45.395  1.00 71.02           N  
+ATOM      2  CA  GLN A  12      17.542  61.927  44.627  1.00 69.89           C  
+ATOM      3  C   GLN A  12      18.708  62.884  44.567  1.00 70.22           C  
+ATOM      4  O   GLN A  12      18.539  64.086  44.298  1.00 75.59           O  
+ATOM      5  CB  GLN A  12      16.241  62.624  45.030  1.00 79.62           C  
+ATOM      6  CG  GLN A  12      14.984  61.791  44.687  1.00100.00           C  
+ATOM      7  CD  GLN A  12      13.825  62.029  45.656  1.00100.00           C  
+ATOM      8  OE1 GLN A  12      13.783  61.447  46.759  1.00100.00           O  
+ATOM      9  NE2 GLN A  12      12.889  62.900  45.257  1.00 90.57           N  
+ATOM     10  N   GLU A  13      19.893  62.356  44.857  1.00 38.43           N  
+ATOM     11  CA  GLU A  13      21.092  63.090  44.635  1.00 44.13           C  
+ATOM     12  C   GLU A  13      21.682  62.662  43.281  1.00 55.94           C  
+ATOM     13  O   GLU A  13      21.442  63.269  42.263  1.00 50.65           O  
+ATOM     14  CB  GLU A  13      22.129  62.981  45.756  1.00 47.59           C  
+ATOM     15  CG  GLU A  13      23.572  63.469  45.286  1.00100.00           C  
+ATOM     16  CD  GLU A  13      23.742  65.011  44.968  1.00100.00           C  
+ATOM     17  OE1 GLU A  13      22.812  65.770  44.559  1.00 78.15           O  
+ATOM     18  OE2 GLU A  13      25.010  65.422  45.116  1.00100.00           O  
+ATOM     19  N   SER A  14      22.353  61.552  43.265  1.00 57.11           N  
+ATOM     20  CA  SER A  14      22.884  61.067  42.035  1.00 70.20           C  
+ATOM     21  C   SER A  14      21.780  60.799  40.982  1.00 79.40           C  
+ATOM     22  O   SER A  14      21.964  61.091  39.799  1.00 88.83           O  
+ATOM     23  CB  SER A  14      23.755  59.855  42.256  1.00 81.81           C  
+ATOM     24  OG  SER A  14      24.588  60.085  43.370  1.00 68.23           O  
+ATOM     25  N   VAL A  15      20.619  60.240  41.446  1.00 71.97           N  
+ATOM     26  CA  VAL A  15      19.444  59.919  40.555  1.00 76.91           C  
+ATOM     27  C   VAL A  15      18.583  61.179  40.094  1.00 81.99           C  
+ATOM     28  O   VAL A  15      17.340  61.184  40.122  1.00 61.20           O  
+ATOM     29  CB  VAL A  15      18.664  58.546  40.931  1.00 73.90           C  
+ATOM     30  CG1 VAL A  15      17.169  58.713  41.243  1.00 77.61           C  
+ATOM     31  CG2 VAL A  15      18.838  57.469  39.848  1.00 63.15           C  
+ATOM     32  N   LYS A  16      19.315  62.253  39.624  1.00 82.22           N  
+ATOM     33  CA  LYS A  16      18.714  63.519  39.106  1.00 82.17           C  
+ATOM     34  C   LYS A  16      19.692  64.284  38.198  1.00 85.25           C  
+ATOM     35  O   LYS A  16      19.288  65.125  37.360  1.00 75.74           O  
+ATOM     36  CB  LYS A  16      18.176  64.427  40.205  1.00100.00           C  
+ATOM     37  CG  LYS A  16      17.271  65.539  39.674  1.00100.00           C  
+ATOM     38  CD  LYS A  16      17.089  66.680  40.672  1.00100.00           C  
+ATOM     39  CE  LYS A  16      15.842  67.532  40.406  1.00100.00           C  
+ATOM     40  NZ  LYS A  16      15.977  68.447  39.250  1.00100.00           N  
+ATOM     41  N   GLU A  17      20.989  63.994  38.415  1.00 78.29           N  
+ATOM     42  CA  GLU A  17      22.096  64.529  37.640  1.00 80.84           C  
+ATOM     43  C   GLU A  17      22.130  63.812  36.302  1.00 95.54           C  
+ATOM     44  O   GLU A  17      22.399  64.373  35.249  1.00100.00           O  
+ATOM     45  CB  GLU A  17      23.445  64.311  38.411  1.00 85.41           C  
+ATOM     46  CG  GLU A  17      24.064  65.619  39.068  1.00100.00           C  
+ATOM     47  CD  GLU A  17      23.436  66.079  40.419  1.00100.00           C  
+ATOM     48  OE1 GLU A  17      22.259  66.454  40.539  1.00100.00           O  
+ATOM     49  OE2 GLU A  17      24.330  66.162  41.406  1.00100.00           O  
+ATOM     50  N   PHE A  18      21.804  62.566  36.404  1.00 87.34           N  
+ATOM     51  CA  PHE A  18      21.672  61.645  35.340  1.00 72.31           C  
+ATOM     52  C   PHE A  18      20.595  62.108  34.385  1.00 53.31           C  
+ATOM     53  O   PHE A  18      20.840  62.690  33.326  1.00 42.09           O  
+ATOM     54  CB  PHE A  18      21.166  60.375  36.010  1.00 71.86           C  
+ATOM     55  CG  PHE A  18      21.653  59.110  35.440  1.00 73.61           C  
+ATOM     56  CD1 PHE A  18      22.981  58.728  35.590  1.00 76.43           C  
+ATOM     57  CD2 PHE A  18      20.754  58.203  34.889  1.00 76.04           C  
+ATOM     58  CE1 PHE A  18      23.431  57.505  35.102  1.00 72.60           C  
+ATOM     59  CE2 PHE A  18      21.178  56.973  34.405  1.00 57.37           C  
+ATOM     60  CZ  PHE A  18      22.522  56.633  34.511  1.00 60.12           C  
+ATOM     61  N   LEU A  19      19.392  61.875  34.844  1.00 47.65           N  
+ATOM     62  CA  LEU A  19      18.157  62.152  34.149  1.00 55.50           C  
+ATOM     63  C   LEU A  19      18.227  63.367  33.279  1.00 66.10           C  
+ATOM     64  O   LEU A  19      17.616  63.422  32.179  1.00 31.20           O  
+ATOM     65  CB  LEU A  19      17.004  62.239  35.162  1.00 44.13           C  
+ATOM     66  CG  LEU A  19      17.160  61.177  36.261  1.00 39.99           C  
+ATOM     67  CD1 LEU A  19      16.141  61.381  37.373  1.00 49.63           C  
+ATOM     68  CD2 LEU A  19      17.020  59.778  35.672  1.00 24.77           C  
+ATOM     69  N   ALA A  20      18.948  64.352  33.784  1.00 91.40           N  
+ATOM     70  CA  ALA A  20      19.150  65.607  33.104  1.00100.00           C  
+ATOM     71  C   ALA A  20      20.329  65.518  32.167  1.00 70.54           C  
+ATOM     72  O   ALA A  20      20.315  66.049  31.032  1.00 54.93           O  
+ATOM     73  CB  ALA A  20      19.352  66.717  34.118  1.00100.00           C  
+ATOM     74  N   LYS A  21      21.356  64.862  32.656  1.00 38.11           N  
+ATOM     75  CA  LYS A  21      22.518  64.619  31.880  1.00 58.14           C  
+ATOM     76  C   LYS A  21      22.115  63.702  30.710  1.00 79.04           C  
+ATOM     77  O   LYS A  21      22.519  63.883  29.542  1.00 79.37           O  
+ATOM     78  CB  LYS A  21      23.585  63.959  32.764  1.00 67.27           C  
+ATOM     79  CG  LYS A  21      24.873  63.613  32.033  1.00100.00           C  
+ATOM     80  CD  LYS A  21      25.632  64.841  31.552  1.00100.00           C  
+ATOM     81  CE  LYS A  21      27.125  64.582  31.327  1.00100.00           C  
+ATOM     82  NZ  LYS A  21      27.950  64.753  32.550  1.00100.00           N  
+ATOM     83  N   ALA A  22      21.232  62.763  31.065  1.00 48.53           N  
+ATOM     84  CA  ALA A  22      20.667  61.777  30.189  1.00 27.03           C  
+ATOM     85  C   ALA A  22      19.558  62.353  29.264  1.00 43.36           C  
+ATOM     86  O   ALA A  22      19.271  61.816  28.207  1.00 33.11           O  
+ATOM     87  CB  ALA A  22      20.081  60.675  31.062  1.00 34.50           C  
+ATOM     88  N   LYS A  23      18.878  63.402  29.716  1.00 53.96           N  
+ATOM     89  CA  LYS A  23      17.846  64.008  28.902  1.00 33.77           C  
+ATOM     90  C   LYS A  23      18.463  64.769  27.743  1.00 54.29           C  
+ATOM     91  O   LYS A  23      17.882  64.901  26.673  1.00 63.26           O  
+ATOM     92  CB  LYS A  23      16.890  64.897  29.698  1.00 45.18           C  
+ATOM     93  CG  LYS A  23      15.896  65.624  28.791  1.00 29.32           C  
+ATOM     94  CD  LYS A  23      14.963  66.544  29.531  1.00 72.53           C  
+ATOM     95  CE  LYS A  23      13.519  66.129  29.403  1.00 92.79           C  
+ATOM     96  NZ  LYS A  23      12.604  67.276  29.292  1.00 73.15           N  
+ATOM     97  N   GLU A  24      19.671  65.239  27.957  1.00 42.57           N  
+ATOM     98  CA  GLU A  24      20.368  65.996  26.964  1.00 56.18           C  
+ATOM     99  C   GLU A  24      21.001  65.103  25.891  1.00 83.24           C  
+ATOM    100  O   GLU A  24      20.619  65.146  24.710  1.00 82.67           O  
+ATOM    101  CB  GLU A  24      21.382  66.959  27.617  1.00 60.71           C  
+ATOM    102  CG  GLU A  24      21.432  68.327  26.912  1.00100.00           C  
+ATOM    103  CD  GLU A  24      22.684  68.527  26.101  1.00100.00           C  
+ATOM    104  OE1 GLU A  24      23.806  68.489  26.589  1.00100.00           O  
+ATOM    105  OE2 GLU A  24      22.436  68.784  24.818  1.00100.00           O  
+ATOM    106  N   ASP A  25      21.951  64.276  26.317  1.00 76.48           N  
+ATOM    107  CA  ASP A  25      22.582  63.338  25.424  1.00 63.58           C  
+ATOM    108  C   ASP A  25      21.562  62.916  24.373  1.00 50.56           C  
+ATOM    109  O   ASP A  25      21.754  63.054  23.156  1.00 47.81           O  
+ATOM    110  CB  ASP A  25      23.049  62.101  26.248  1.00 68.29           C  
+ATOM    111  CG  ASP A  25      24.245  61.383  25.691  1.00100.00           C  
+ATOM    112  OD1 ASP A  25      24.284  60.940  24.560  1.00100.00           O  
+ATOM    113  OD2 ASP A  25      25.238  61.251  26.567  1.00 90.40           O  
+ATOM    114  N   PHE A  26      20.432  62.474  24.881  1.00 27.58           N  
+ATOM    115  CA  PHE A  26      19.365  62.023  24.075  1.00 22.42           C  
+ATOM    116  C   PHE A  26      18.897  63.096  23.118  1.00 50.40           C  
+ATOM    117  O   PHE A  26      19.022  62.960  21.909  1.00 64.08           O  
+ATOM    118  CB  PHE A  26      18.253  61.455  24.946  1.00 19.16           C  
+ATOM    119  CG  PHE A  26      16.909  61.452  24.298  1.00  7.10           C  
+ATOM    120  CD1 PHE A  26      16.470  60.368  23.557  1.00 30.88           C  
+ATOM    121  CD2 PHE A  26      16.046  62.532  24.446  1.00 15.05           C  
+ATOM    122  CE1 PHE A  26      15.205  60.357  22.962  1.00 22.78           C  
+ATOM    123  CE2 PHE A  26      14.774  62.534  23.871  1.00 26.81           C  
+ATOM    124  CZ  PHE A  26      14.355  61.437  23.123  1.00  6.70           C  
+ATOM    125  N   LEU A  27      18.444  64.217  23.669  1.00 73.54           N  
+ATOM    126  CA  LEU A  27      17.961  65.327  22.850  1.00 59.17           C  
+ATOM    127  C   LEU A  27      18.703  65.439  21.546  1.00 72.30           C  
+ATOM    128  O   LEU A  27      18.124  65.237  20.481  1.00 81.48           O  
+ATOM    129  CB  LEU A  27      17.891  66.637  23.614  1.00 41.02           C  
+ATOM    130  CG  LEU A  27      16.501  66.909  24.114  1.00 22.03           C  
+ATOM    131  CD1 LEU A  27      16.519  68.172  24.935  1.00 40.44           C  
+ATOM    132  CD2 LEU A  27      15.563  67.070  22.936  1.00 57.94           C  
+ATOM    133  N   LYS A  28      20.020  65.661  21.638  1.00 40.33           N  
+ATOM    134  CA  LYS A  28      20.827  65.697  20.475  1.00 26.65           C  
+ATOM    135  C   LYS A  28      20.417  64.592  19.548  1.00 52.89           C  
+ATOM    136  O   LYS A  28      19.596  64.801  18.666  1.00 51.02           O  
+ATOM    137  CB  LYS A  28      22.286  65.588  20.817  1.00 24.95           C  
+ATOM    138  CG  LYS A  28      22.868  66.923  21.259  1.00 93.48           C  
+ATOM    139  CD  LYS A  28      24.041  66.802  22.235  1.00100.00           C  
+ATOM    140  CE  LYS A  28      24.681  68.163  22.561  1.00 42.68           C  
+ATOM    141  NZ  LYS A  28      25.718  68.103  23.620  1.00 53.58           N  
+ATOM    142  N   LYS A  29      20.922  63.367  19.807  1.00 33.48           N  
+ATOM    143  CA  LYS A  29      20.554  62.250  18.952  1.00 23.10           C  
+ATOM    144  C   LYS A  29      19.140  62.432  18.439  1.00 41.61           C  
+ATOM    145  O   LYS A  29      18.885  62.499  17.240  1.00 44.26           O  
+ATOM    146  CB  LYS A  29      20.692  60.899  19.616  1.00 30.08           C  
+ATOM    147  CG  LYS A  29      22.086  60.644  20.192  1.00 70.61           C  
+ATOM    148  CD  LYS A  29      22.204  59.253  20.864  1.00 38.36           C  
+ATOM    149  CE  LYS A  29      23.518  59.024  21.612  1.00 79.47           C  
+ATOM    150  NZ  LYS A  29      24.562  58.353  20.812  1.00 63.77           N  
+ATOM    151  N   TRP A  30      18.197  62.573  19.356  1.00 30.01           N  
+ATOM    152  CA  TRP A  30      16.840  62.782  18.955  1.00 33.27           C  
+ATOM    153  C   TRP A  30      16.823  63.674  17.809  1.00 30.52           C  
+ATOM    154  O   TRP A  30      16.425  63.337  16.789  1.00 51.75           O  
+ATOM    155  CB  TRP A  30      15.995  63.440  20.060  1.00 30.87           C  
+ATOM    156  CG  TRP A  30      14.571  63.574  19.610  1.00 29.46           C  
+ATOM    157  CD1 TRP A  30      13.896  64.695  19.307  1.00 34.42           C  
+ATOM    158  CD2 TRP A  30      13.657  62.509  19.348  1.00 37.93           C  
+ATOM    159  NE1 TRP A  30      12.594  64.426  19.017  1.00 40.21           N  
+ATOM    160  CE2 TRP A  30      12.430  63.073  18.963  1.00 43.37           C  
+ATOM    161  CE3 TRP A  30      13.746  61.120  19.493  1.00 42.02           C  
+ATOM    162  CZ2 TRP A  30      11.296  62.286  18.692  1.00 39.86           C  
+ATOM    163  CZ3 TRP A  30      12.625  60.341  19.248  1.00 38.51           C  
+ATOM    164  CH2 TRP A  30      11.412  60.938  18.846  1.00 31.02           C  
+ATOM    165  N   GLU A  31      17.382  64.829  18.014  1.00 42.81           N  
+ATOM    166  CA  GLU A  31      17.425  65.859  17.047  1.00 65.61           C  
+ATOM    167  C   GLU A  31      18.602  65.796  16.034  1.00 59.94           C  
+ATOM    168  O   GLU A  31      19.299  66.773  15.783  1.00 60.55           O  
+ATOM    169  CB  GLU A  31      17.192  67.278  17.659  1.00 78.08           C  
+ATOM    170  CG  GLU A  31      18.011  67.568  18.931  1.00100.00           C  
+ATOM    171  CD  GLU A  31      18.656  68.967  18.950  1.00100.00           C  
+ATOM    172  OE1 GLU A  31      17.781  69.878  19.459  1.00 93.22           O  
+ATOM    173  OE2 GLU A  31      19.810  69.179  18.649  1.00100.00           O  
+ATOM    174  N   THR A  32      18.790  64.569  15.471  1.00 65.65           N  
+ATOM    175  CA  THR A  32      19.810  64.238  14.442  1.00 65.32           C  
+ATOM    176  C   THR A  32      20.126  62.759  14.409  1.00 72.93           C  
+ATOM    177  O   THR A  32      21.004  62.291  15.137  1.00 65.73           O  
+ATOM    178  CB  THR A  32      21.104  65.077  14.508  1.00 91.28           C  
+ATOM    179  OG1 THR A  32      21.352  65.568  15.817  1.00 74.32           O  
+ATOM    180  CG2 THR A  32      21.019  66.212  13.507  1.00100.00           C  
+ATOM    181  N   PRO A  33      19.392  62.016  13.543  1.00 81.60           N  
+ATOM    182  CA  PRO A  33      19.524  60.542  13.443  1.00 84.31           C  
+ATOM    183  C   PRO A  33      20.300  60.039  12.214  1.00 72.11           C  
+ATOM    184  O   PRO A  33      19.787  60.077  11.078  1.00 73.78           O  
+ATOM    185  CB  PRO A  33      18.082  60.013  13.324  1.00 77.90           C  
+ATOM    186  CG  PRO A  33      17.189  61.213  12.978  1.00 68.27           C  
+ATOM    187  CD  PRO A  33      18.005  62.473  13.255  1.00 64.30           C  
+ATOM    188  N   SER A  34      21.463  59.450  12.433  1.00 42.04           N  
+ATOM    189  CA  SER A  34      22.113  58.877  11.318  1.00 41.23           C  
+ATOM    190  C   SER A  34      21.090  57.999  10.634  1.00 56.43           C  
+ATOM    191  O   SER A  34      20.177  57.475  11.287  1.00 34.31           O  
+ATOM    192  CB  SER A  34      23.337  58.061  11.716  1.00 59.22           C  
+ATOM    193  OG  SER A  34      24.247  57.977  10.615  1.00 92.95           O  
+ATOM    194  N   GLN A  35      21.150  57.906   9.320  1.00 72.62           N  
+ATOM    195  CA  GLN A  35      20.238  57.015   8.621  1.00 73.23           C  
+ATOM    196  C   GLN A  35      21.006  55.907   7.960  1.00 67.37           C  
+ATOM    197  O   GLN A  35      21.880  55.332   8.553  1.00100.00           O  
+ATOM    198  CB  GLN A  35      19.253  57.707   7.697  1.00 79.74           C  
+ATOM    199  CG  GLN A  35      19.911  58.473   6.556  1.00100.00           C  
+ATOM    200  CD  GLN A  35      18.880  59.053   5.595  1.00100.00           C  
+ATOM    201  OE1 GLN A  35      19.218  59.763   4.632  1.00100.00           O  
+ATOM    202  NE2 GLN A  35      17.598  58.789   5.908  1.00100.00           N  
+ATOM    203  N   ASN A  36      20.775  55.650   6.722  1.00 53.21           N  
+ATOM    204  CA  ASN A  36      21.583  54.602   6.072  1.00 59.91           C  
+ATOM    205  C   ASN A  36      22.897  54.326   6.823  1.00 71.76           C  
+ATOM    206  O   ASN A  36      23.775  55.200   6.921  1.00 73.03           O  
+ATOM    207  CB  ASN A  36      21.957  54.983   4.635  1.00 91.42           C  
+ATOM    208  CG  ASN A  36      20.866  54.764   3.625  1.00100.00           C  
+ATOM    209  OD1 ASN A  36      19.896  53.972   3.837  1.00 53.62           O  
+ATOM    210  ND2 ASN A  36      21.037  55.461   2.477  1.00 71.05           N  
+ATOM    211  N   THR A  37      23.068  53.068   7.268  1.00 71.77           N  
+ATOM    212  CA  THR A  37      24.291  52.647   7.970  1.00 70.89           C  
+ATOM    213  C   THR A  37      24.749  51.254   7.516  1.00 50.52           C  
+ATOM    214  O   THR A  37      25.713  50.716   8.033  1.00 27.90           O  
+ATOM    215  CB  THR A  37      24.228  52.799   9.567  1.00 66.98           C  
+ATOM    216  OG1 THR A  37      23.966  54.133   9.906  1.00 41.90           O  
+ATOM    217  CG2 THR A  37      25.575  52.373  10.259  1.00 29.84           C  
+ATOM    218  N   ALA A  38      24.065  50.683   6.517  1.00 56.74           N  
+ATOM    219  CA  ALA A  38      24.487  49.386   6.005  1.00 53.92           C  
+ATOM    220  C   ALA A  38      23.671  48.877   4.852  1.00 39.82           C  
+ATOM    221  O   ALA A  38      22.614  49.399   4.506  1.00 35.87           O  
+ATOM    222  CB  ALA A  38      24.589  48.338   7.102  1.00 52.74           C  
+ATOM    223  N   GLN A  39      24.123  47.832   4.311  1.00 14.22           N  
+ATOM    224  CA  GLN A  39      23.395  47.282   3.270  1.00 27.69           C  
+ATOM    225  C   GLN A  39      23.115  45.852   3.575  1.00 43.48           C  
+ATOM    226  O   GLN A  39      23.895  45.228   4.280  1.00 23.05           O  
+ATOM    227  CB  GLN A  39      24.077  47.497   1.914  1.00 21.85           C  
+ATOM    228  CG  GLN A  39      25.383  48.288   2.022  1.00 85.28           C  
+ATOM    229  CD  GLN A  39      25.591  49.201   0.856  1.00 73.21           C  
+ATOM    230  OE1 GLN A  39      26.512  50.051   0.855  1.00 86.59           O  
+ATOM    231  NE2 GLN A  39      24.659  49.122  -0.077  1.00 57.53           N  
+ATOM    232  N   LEU A  40      21.922  45.379   3.131  1.00 35.56           N  
+ATOM    233  CA  LEU A  40      21.446  44.028   3.356  1.00  9.94           C  
+ATOM    234  C   LEU A  40      22.537  42.960   3.169  1.00 19.11           C  
+ATOM    235  O   LEU A  40      22.668  42.048   3.974  1.00 22.42           O  
+ATOM    236  CB  LEU A  40      20.296  43.765   2.417  1.00 13.16           C  
+ATOM    237  CG  LEU A  40      19.259  42.855   3.000  1.00 28.39           C  
+ATOM    238  CD1 LEU A  40      18.380  42.347   1.891  1.00 29.30           C  
+ATOM    239  CD2 LEU A  40      19.905  41.692   3.715  1.00 15.46           C  
+ATOM    240  N   ASP A  41      23.311  43.096   2.086  1.00 61.13           N  
+ATOM    241  CA  ASP A  41      24.377  42.130   1.703  1.00 67.57           C  
+ATOM    242  C   ASP A  41      25.496  41.956   2.728  1.00 69.90           C  
+ATOM    243  O   ASP A  41      26.288  41.012   2.637  1.00 62.53           O  
+ATOM    244  CB  ASP A  41      25.006  42.473   0.339  1.00 73.49           C  
+ATOM    245  CG  ASP A  41      24.016  42.777  -0.749  1.00 87.77           C  
+ATOM    246  OD1 ASP A  41      22.858  42.356  -0.744  1.00 83.03           O  
+ATOM    247  OD2 ASP A  41      24.559  43.494  -1.747  1.00 51.72           O  
+ATOM    248  N   GLN A  42      25.629  42.920   3.628  1.00 61.51           N  
+ATOM    249  CA  GLN A  42      26.648  42.845   4.619  1.00 40.04           C  
+ATOM    250  C   GLN A  42      26.319  41.768   5.569  1.00 13.88           C  
+ATOM    251  O   GLN A  42      27.136  41.360   6.321  1.00 30.76           O  
+ATOM    252  CB  GLN A  42      26.857  44.176   5.336  1.00 43.11           C  
+ATOM    253  CG  GLN A  42      26.984  45.368   4.351  1.00 42.06           C  
+ATOM    254  CD  GLN A  42      27.368  46.689   5.012  1.00 35.34           C  
+ATOM    255  OE1 GLN A  42      26.712  47.713   4.804  1.00 56.32           O  
+ATOM    256  NE2 GLN A  42      28.414  46.651   5.837  1.00 99.59           N  
+ATOM    257  N   PHE A  43      25.115  41.218   5.389  1.00 13.23           N  
+ATOM    258  CA  PHE A  43      24.569  40.205   6.233  1.00 21.13           C  
+ATOM    259  C   PHE A  43      24.115  38.979   5.510  1.00 34.09           C  
+ATOM    260  O   PHE A  43      23.563  39.060   4.431  1.00 42.88           O  
+ATOM    261  CB  PHE A  43      23.318  40.742   6.946  1.00 29.82           C  
+ATOM    262  CG  PHE A  43      23.528  42.060   7.599  1.00 45.98           C  
+ATOM    263  CD1 PHE A  43      24.222  42.152   8.817  1.00 49.41           C  
+ATOM    264  CD2 PHE A  43      22.981  43.221   7.044  1.00 29.91           C  
+ATOM    265  CE1 PHE A  43      24.425  43.386   9.446  1.00 17.36           C  
+ATOM    266  CE2 PHE A  43      23.134  44.457   7.675  1.00 25.26           C  
+ATOM    267  CZ  PHE A  43      23.867  44.534   8.869  1.00 28.88           C  
+ATOM    268  N   ASP A  44      24.169  37.862   6.250  1.00 16.62           N  
+ATOM    269  CA  ASP A  44      23.691  36.583   5.843  1.00 15.81           C  
+ATOM    270  C   ASP A  44      22.478  36.240   6.614  1.00 13.96           C  
+ATOM    271  O   ASP A  44      22.557  36.009   7.779  1.00 25.41           O  
+ATOM    272  CB  ASP A  44      24.753  35.497   6.136  1.00 28.11           C  
+ATOM    273  CG  ASP A  44      25.403  34.902   4.920  1.00 64.49           C  
+ATOM    274  OD1 ASP A  44      24.790  34.176   4.100  1.00 58.68           O  
+ATOM    275  OD2 ASP A  44      26.704  35.125   4.902  1.00 37.33           O  
+ATOM    276  N   ARG A  45      21.360  36.157   5.965  1.00 31.02           N  
+ATOM    277  CA  ARG A  45      20.126  35.786   6.661  1.00 13.66           C  
+ATOM    278  C   ARG A  45      20.144  34.341   7.188  1.00 30.00           C  
+ATOM    279  O   ARG A  45      20.247  33.389   6.434  1.00 44.64           O  
+ATOM    280  CB  ARG A  45      18.855  36.069   5.831  1.00 12.59           C  
+ATOM    281  CG  ARG A  45      19.144  36.621   4.436  1.00100.00           C  
+ATOM    282  CD  ARG A  45      19.541  38.104   4.443  1.00100.00           C  
+ATOM    283  NE  ARG A  45      20.593  38.436   3.450  1.00100.00           N  
+ATOM    284  CZ  ARG A  45      20.372  39.106   2.295  1.00100.00           C  
+ATOM    285  NH1 ARG A  45      19.155  39.554   1.957  1.00100.00           N  
+ATOM    286  NH2 ARG A  45      21.406  39.362   1.462  1.00100.00           N  
+ATOM    287  N   ILE A  46      19.983  34.214   8.495  1.00 30.83           N  
+ATOM    288  CA  ILE A  46      19.985  32.942   9.160  1.00 12.73           C  
+ATOM    289  C   ILE A  46      18.583  32.364   9.439  1.00 33.33           C  
+ATOM    290  O   ILE A  46      18.252  31.258   9.012  1.00 47.63           O  
+ATOM    291  CB  ILE A  46      20.744  33.016  10.456  1.00 33.89           C  
+ATOM    292  CG1 ILE A  46      22.247  33.267  10.233  1.00 40.48           C  
+ATOM    293  CG2 ILE A  46      20.512  31.747  11.242  1.00 36.83           C  
+ATOM    294  CD1 ILE A  46      23.081  31.998  10.079  1.00 20.88           C  
+ATOM    295  N   LYS A  47      17.778  33.076  10.217  1.00 44.18           N  
+ATOM    296  CA  LYS A  47      16.497  32.506  10.605  1.00 33.18           C  
+ATOM    297  C   LYS A  47      15.515  33.550  11.128  1.00 34.96           C  
+ATOM    298  O   LYS A  47      15.929  34.563  11.709  1.00 24.18           O  
+ATOM    299  CB  LYS A  47      16.745  31.439  11.683  1.00 25.42           C  
+ATOM    300  CG  LYS A  47      15.554  30.542  11.934  1.00100.00           C  
+ATOM    301  CD  LYS A  47      15.639  29.765  13.249  1.00 69.87           C  
+ATOM    302  CE  LYS A  47      14.381  28.922  13.512  1.00 99.15           C  
+ATOM    303  NZ  LYS A  47      14.336  28.322  14.867  1.00 61.16           N  
+ATOM    304  N   THR A  48      14.186  33.239  10.980  1.00 22.54           N  
+ATOM    305  CA  THR A  48      13.115  34.110  11.484  1.00 16.37           C  
+ATOM    306  C   THR A  48      12.852  33.952  12.988  1.00 28.85           C  
+ATOM    307  O   THR A  48      12.433  32.892  13.445  1.00 46.54           O  
+ATOM    308  CB  THR A  48      11.830  33.927  10.760  1.00  6.21           C  
+ATOM    309  OG1 THR A  48      11.944  34.408   9.460  1.00 80.33           O  
+ATOM    310  CG2 THR A  48      10.745  34.709  11.521  1.00  3.28           C  
+ATOM    311  N   LEU A  49      12.964  35.074  13.713  1.00 33.54           N  
+ATOM    312  CA  LEU A  49      12.806  35.143  15.175  1.00 22.81           C  
+ATOM    313  C   LEU A  49      11.389  35.461  15.689  1.00 37.34           C  
+ATOM    314  O   LEU A  49      10.839  34.765  16.564  1.00 32.80           O  
+ATOM    315  CB  LEU A  49      13.776  36.153  15.748  1.00 22.77           C  
+ATOM    316  CG  LEU A  49      15.224  35.697  15.622  1.00 30.83           C  
+ATOM    317  CD1 LEU A  49      16.147  36.705  16.303  1.00 11.49           C  
+ATOM    318  CD2 LEU A  49      15.398  34.302  16.254  1.00  2.07           C  
+ATOM    319  N   GLY A  50      10.854  36.564  15.272  1.00 36.03           N  
+ATOM    320  CA  GLY A  50       9.541  36.950  15.759  1.00 49.32           C  
+ATOM    321  C   GLY A  50       8.747  37.529  14.669  1.00 66.32           C  
+ATOM    322  O   GLY A  50       9.229  37.646  13.555  1.00 64.86           O  
+ATOM    323  N   THR A  51       7.537  37.942  14.960  1.00 84.91           N  
+ATOM    324  CA  THR A  51       6.762  38.501  13.887  1.00 91.75           C  
+ATOM    325  C   THR A  51       6.223  39.925  14.052  1.00100.00           C  
+ATOM    326  O   THR A  51       6.587  40.702  14.986  1.00 81.59           O  
+ATOM    327  CB  THR A  51       5.771  37.543  13.221  1.00 46.72           C  
+ATOM    328  OG1 THR A  51       4.812  37.081  14.166  1.00100.00           O  
+ATOM    329  CG2 THR A  51       6.540  36.375  12.587  1.00 46.58           C  
+ATOM    330  N   GLY A  52       5.397  40.269  13.052  1.00100.00           N  
+ATOM    331  CA  GLY A  52       4.765  41.547  12.910  1.00100.00           C  
+ATOM    332  C   GLY A  52       3.883  41.596  11.646  1.00100.00           C  
+ATOM    333  O   GLY A  52       4.191  40.972  10.597  1.00 84.44           O  
+ATOM    334  N   SER A  53       2.775  42.313  11.781  1.00100.00           N  
+ATOM    335  CA  SER A  53       1.836  42.512  10.703  1.00100.00           C  
+ATOM    336  C   SER A  53       2.416  43.512   9.712  1.00 91.35           C  
+ATOM    337  O   SER A  53       1.831  43.796   8.653  1.00100.00           O  
+ATOM    338  CB  SER A  53       0.480  42.994  11.241  1.00100.00           C  
+ATOM    339  OG  SER A  53       0.317  42.587  12.608  1.00 57.28           O  
+ATOM    340  N   PHE A  54       3.599  44.038  10.074  1.00 55.62           N  
+ATOM    341  CA  PHE A  54       4.270  44.996   9.260  1.00 54.13           C  
+ATOM    342  C   PHE A  54       5.752  44.730   9.127  1.00 82.21           C  
+ATOM    343  O   PHE A  54       6.551  45.651   9.015  1.00 97.82           O  
+ATOM    344  CB  PHE A  54       3.928  46.485   9.598  1.00 48.78           C  
+ATOM    345  CG  PHE A  54       4.326  46.949  10.992  1.00 72.75           C  
+ATOM    346  CD1 PHE A  54       5.378  46.348  11.692  1.00 99.19           C  
+ATOM    347  CD2 PHE A  54       3.694  48.054  11.572  1.00 89.89           C  
+ATOM    348  CE1 PHE A  54       5.757  46.799  12.962  1.00100.00           C  
+ATOM    349  CE2 PHE A  54       4.067  48.527  12.834  1.00100.00           C  
+ATOM    350  CZ  PHE A  54       5.104  47.897  13.529  1.00100.00           C  
+ATOM    351  N   GLY A  55       6.111  43.450   9.091  1.00 76.79           N  
+ATOM    352  CA  GLY A  55       7.500  43.079   8.935  1.00 75.97           C  
+ATOM    353  C   GLY A  55       7.795  41.660   9.396  1.00 59.77           C  
+ATOM    354  O   GLY A  55       6.974  40.765   9.240  1.00 62.25           O  
+ATOM    355  N   ARG A  56       9.002  41.495   9.982  1.00 30.71           N  
+ATOM    356  CA  ARG A  56       9.540  40.216  10.455  1.00  5.33           C  
+ATOM    357  C   ARG A  56      10.858  40.451  11.202  1.00 54.57           C  
+ATOM    358  O   ARG A  56      11.700  41.261  10.775  1.00 55.04           O  
+ATOM    359  CB  ARG A  56       9.870  39.312   9.266  1.00 35.06           C  
+ATOM    360  CG  ARG A  56       8.679  38.617   8.642  1.00100.00           C  
+ATOM    361  CD  ARG A  56       9.100  37.515   7.670  1.00 47.43           C  
+ATOM    362  NE  ARG A  56       8.347  36.276   7.859  1.00100.00           N  
+ATOM    363  CZ  ARG A  56       8.880  35.054   7.768  1.00100.00           C  
+ATOM    364  NH1 ARG A  56      10.181  34.868   7.491  1.00 38.05           N  
+ATOM    365  NH2 ARG A  56       8.088  33.995   7.983  1.00 83.16           N  
+ATOM    366  N   VAL A  57      11.065  39.759  12.297  1.00 54.59           N  
+ATOM    367  CA  VAL A  57      12.333  39.887  12.944  1.00 49.18           C  
+ATOM    368  C   VAL A  57      13.089  38.642  12.866  1.00 23.57           C  
+ATOM    369  O   VAL A  57      12.700  37.635  13.431  1.00 48.21           O  
+ATOM    370  CB  VAL A  57      12.350  40.524  14.338  1.00 37.31           C  
+ATOM    371  CG1 VAL A  57      13.528  39.950  15.117  1.00 39.63           C  
+ATOM    372  CG2 VAL A  57      12.569  42.034  14.184  1.00 19.74           C  
+ATOM    373  N   MET A  58      14.185  38.700  12.177  1.00 19.07           N  
+ATOM    374  CA  MET A  58      14.949  37.533  11.997  1.00 28.68           C  
+ATOM    375  C   MET A  58      16.400  37.688  12.251  1.00 19.74           C  
+ATOM    376  O   MET A  58      16.952  38.818  12.339  1.00 34.35           O  
+ATOM    377  CB  MET A  58      14.679  36.844  10.665  1.00 48.08           C  
+ATOM    378  CG  MET A  58      15.513  37.376   9.518  1.00 55.76           C  
+ATOM    379  SD  MET A  58      15.067  36.591   7.948  1.00 45.80           S  
+ATOM    380  CE  MET A  58      13.262  36.832   8.004  1.00 49.46           C  
+ATOM    381  N   LEU A  59      17.004  36.522  12.388  1.00 22.07           N  
+ATOM    382  CA  LEU A  59      18.380  36.337  12.726  1.00 26.76           C  
+ATOM    383  C   LEU A  59      19.329  36.514  11.502  1.00 38.93           C  
+ATOM    384  O   LEU A  59      19.132  35.889  10.478  1.00 33.23           O  
+ATOM    385  CB  LEU A  59      18.533  34.938  13.402  1.00  4.60           C  
+ATOM    386  CG  LEU A  59      19.909  34.720  13.967  1.00 22.99           C  
+ATOM    387  CD1 LEU A  59      20.191  35.784  15.026  1.00 24.84           C  
+ATOM    388  CD2 LEU A  59      20.027  33.309  14.564  1.00 15.20           C  
+ATOM    389  N   VAL A  60      20.367  37.362  11.639  1.00 10.86           N  
+ATOM    390  CA  VAL A  60      21.306  37.589  10.545  1.00 14.16           C  
+ATOM    391  C   VAL A  60      22.734  37.591  11.010  1.00 23.60           C  
+ATOM    392  O   VAL A  60      23.030  38.028  12.078  1.00 29.72           O  
+ATOM    393  CB  VAL A  60      21.007  38.891   9.854  1.00 22.65           C  
+ATOM    394  CG1 VAL A  60      19.524  39.048   9.760  1.00 25.44           C  
+ATOM    395  CG2 VAL A  60      21.572  40.022  10.663  1.00 11.42           C  
+ATOM    396  N   LYS A  61      23.626  37.076  10.194  1.00 48.55           N  
+ATOM    397  CA  LYS A  61      25.043  37.033  10.572  1.00 48.07           C  
+ATOM    398  C   LYS A  61      25.840  38.067   9.804  1.00 38.60           C  
+ATOM    399  O   LYS A  61      25.815  38.102   8.584  1.00 72.49           O  
+ATOM    400  CB  LYS A  61      25.661  35.604  10.437  1.00 35.74           C  
+ATOM    401  CG  LYS A  61      27.024  35.443  11.132  1.00 10.07           C  
+ATOM    402  CD  LYS A  61      27.970  34.504  10.400  1.00 35.44           C  
+ATOM    403  CE  LYS A  61      29.444  34.994  10.407  1.00100.00           C  
+ATOM    404  NZ  LYS A  61      30.281  34.479   9.274  1.00 83.41           N  
+ATOM    405  N   HIS A  62      26.501  38.939  10.519  1.00 25.64           N  
+ATOM    406  CA  HIS A  62      27.300  39.933   9.874  1.00 31.80           C  
+ATOM    407  C   HIS A  62      28.573  39.303   9.313  1.00 58.47           C  
+ATOM    408  O   HIS A  62      29.331  38.646  10.029  1.00 44.39           O  
+ATOM    409  CB  HIS A  62      27.558  41.180  10.749  1.00 19.46           C  
+ATOM    410  CG  HIS A  62      28.473  42.238  10.115  1.00 38.28           C  
+ATOM    411  ND1 HIS A  62      29.870  42.083  10.070  1.00 35.14           N  
+ATOM    412  CD2 HIS A  62      28.171  43.465   9.568  1.00 35.96           C  
+ATOM    413  CE1 HIS A  62      30.358  43.198   9.514  1.00 39.71           C  
+ATOM    414  NE2 HIS A  62      29.367  44.043   9.202  1.00 38.95           N  
+ATOM    415  N   LYS A  63      28.728  39.440   7.991  1.00 69.03           N  
+ATOM    416  CA  LYS A  63      29.828  38.877   7.255  1.00 46.86           C  
+ATOM    417  C   LYS A  63      31.179  39.086   7.937  1.00 68.34           C  
+ATOM    418  O   LYS A  63      31.764  38.113   8.452  1.00 83.87           O  
+ATOM    419  CB  LYS A  63      29.802  39.273   5.768  1.00 68.03           C  
+ATOM    420  CG  LYS A  63      29.186  38.181   4.859  1.00 31.44           C  
+ATOM    421  CD  LYS A  63      28.473  38.735   3.633  1.00 43.48           C  
+ATOM    422  CE  LYS A  63      26.977  38.525   3.700  1.00 57.98           C  
+ATOM    423  NZ  LYS A  63      26.370  38.363   2.371  1.00 23.63           N  
+ATOM    424  N   GLU A  64      31.666  40.371   7.984  1.00 56.71           N  
+ATOM    425  CA  GLU A  64      32.962  40.673   8.633  1.00 64.77           C  
+ATOM    426  C   GLU A  64      32.985  40.096   9.999  1.00 95.44           C  
+ATOM    427  O   GLU A  64      33.234  38.897  10.211  1.00100.00           O  
+ATOM    428  CB  GLU A  64      33.240  42.187   8.769  1.00 65.29           C  
+ATOM    429  CG  GLU A  64      32.971  42.982   7.498  1.00 89.56           C  
+ATOM    430  CD  GLU A  64      33.770  44.239   7.442  1.00100.00           C  
+ATOM    431  OE1 GLU A  64      34.987  44.252   7.453  1.00 55.10           O  
+ATOM    432  OE2 GLU A  64      33.014  45.319   7.462  1.00100.00           O  
+ATOM    433  N   SER A  65      32.695  40.959  10.931  1.00 62.13           N  
+ATOM    434  CA  SER A  65      32.596  40.581  12.272  1.00 43.89           C  
+ATOM    435  C   SER A  65      31.485  39.574  12.417  1.00 32.25           C  
+ATOM    436  O   SER A  65      30.311  39.897  12.248  1.00 72.02           O  
+ATOM    437  CB  SER A  65      32.330  41.793  13.124  1.00 66.72           C  
+ATOM    438  OG  SER A  65      31.400  42.638  12.466  1.00 99.42           O  
+ATOM    439  N   GLY A  66      31.860  38.339  12.658  1.00 29.45           N  
+ATOM    440  CA  GLY A  66      30.905  37.272  12.843  1.00 30.95           C  
+ATOM    441  C   GLY A  66      29.967  37.538  13.994  1.00 42.57           C  
+ATOM    442  O   GLY A  66      29.891  36.781  14.958  1.00 77.97           O  
+ATOM    443  N   ASN A  67      29.251  38.632  13.878  1.00 23.75           N  
+ATOM    444  CA  ASN A  67      28.344  39.046  14.856  1.00 35.73           C  
+ATOM    445  C   ASN A  67      26.969  38.981  14.390  1.00 24.78           C  
+ATOM    446  O   ASN A  67      26.612  39.654  13.457  1.00 37.89           O  
+ATOM    447  CB  ASN A  67      28.634  40.481  15.356  1.00 21.41           C  
+ATOM    448  CG  ASN A  67      30.030  40.667  15.799  1.00 52.17           C  
+ATOM    449  OD1 ASN A  67      30.541  41.791  15.862  1.00100.00           O  
+ATOM    450  ND2 ASN A  67      30.670  39.535  16.108  1.00100.00           N  
+ATOM    451  N   HIS A  68      26.193  38.167  15.043  1.00 13.61           N  
+ATOM    452  CA  HIS A  68      24.829  38.131  14.766  1.00  7.58           C  
+ATOM    453  C   HIS A  68      24.239  39.355  15.381  1.00 26.77           C  
+ATOM    454  O   HIS A  68      24.754  39.898  16.392  1.00 36.26           O  
+ATOM    455  CB  HIS A  68      24.155  36.882  15.289  1.00 20.09           C  
+ATOM    456  CG  HIS A  68      24.961  35.649  15.085  1.00 27.11           C  
+ATOM    457  ND1 HIS A  68      26.308  35.577  15.477  1.00 30.77           N  
+ATOM    458  CD2 HIS A  68      24.591  34.464  14.523  1.00 25.10           C  
+ATOM    459  CE1 HIS A  68      26.721  34.348  15.106  1.00 35.28           C  
+ATOM    460  NE2 HIS A  68      25.728  33.659  14.492  1.00 26.77           N  
+ATOM    461  N   TYR A  69      23.205  39.814  14.741  1.00 17.34           N  
+ATOM    462  CA  TYR A  69      22.389  40.917  15.171  1.00 10.79           C  
+ATOM    463  C   TYR A  69      20.988  40.422  15.044  1.00  9.74           C  
+ATOM    464  O   TYR A  69      20.810  39.255  14.923  1.00 18.53           O  
+ATOM    465  CB  TYR A  69      22.644  42.174  14.320  1.00  7.69           C  
+ATOM    466  CG  TYR A  69      24.052  42.665  14.485  1.00 15.60           C  
+ATOM    467  CD1 TYR A  69      24.392  43.510  15.534  1.00 28.15           C  
+ATOM    468  CD2 TYR A  69      25.073  42.184  13.675  1.00 14.90           C  
+ATOM    469  CE1 TYR A  69      25.713  43.905  15.748  1.00 49.51           C  
+ATOM    470  CE2 TYR A  69      26.400  42.579  13.860  1.00 25.25           C  
+ATOM    471  CZ  TYR A  69      26.719  43.422  14.919  1.00 21.97           C  
+ATOM    472  OH  TYR A  69      28.004  43.801  15.127  1.00 33.56           O  
+ATOM    473  N   ALA A  70      20.005  41.285  15.050  1.00 30.54           N  
+ATOM    474  CA  ALA A  70      18.593  40.880  14.810  1.00 21.74           C  
+ATOM    475  C   ALA A  70      17.905  41.969  14.079  1.00 36.99           C  
+ATOM    476  O   ALA A  70      18.003  43.144  14.451  1.00 46.52           O  
+ATOM    477  CB  ALA A  70      17.832  40.515  16.035  1.00 22.48           C  
+ATOM    478  N   MET A  71      17.386  41.580  12.974  1.00 13.80           N  
+ATOM    479  CA  MET A  71      16.945  42.509  11.987  1.00  7.37           C  
+ATOM    480  C   MET A  71      15.451  42.497  11.922  1.00 25.79           C  
+ATOM    481  O   MET A  71      14.839  41.488  11.544  1.00 19.26           O  
+ATOM    482  CB  MET A  71      17.641  42.219  10.684  1.00 39.77           C  
+ATOM    483  CG  MET A  71      16.710  42.275   9.487  1.00 64.37           C  
+ATOM    484  SD  MET A  71      17.577  42.688   8.002  1.00 56.17           S  
+ATOM    485  CE  MET A  71      19.245  43.170   8.406  1.00 36.33           C  
+ATOM    486  N   LYS A  72      14.913  43.596  12.345  1.00  1.00           N  
+ATOM    487  CA  LYS A  72      13.552  43.921  12.055  1.00 21.81           C  
+ATOM    488  C   LYS A  72      13.448  44.476  10.630  1.00 27.79           C  
+ATOM    489  O   LYS A  72      14.272  45.267  10.228  1.00 22.25           O  
+ATOM    490  CB  LYS A  72      12.994  44.897  13.087  1.00  8.78           C  
+ATOM    491  CG  LYS A  72      11.470  44.807  13.206  1.00 29.03           C  
+ATOM    492  CD  LYS A  72      10.813  46.132  13.585  1.00 11.00           C  
+ATOM    493  CE  LYS A  72      10.535  46.246  15.084  1.00 44.77           C  
+ATOM    494  NZ  LYS A  72       9.352  47.063  15.388  1.00 48.98           N  
+ATOM    495  N   ILE A  73      12.488  43.972   9.857  1.00 24.69           N  
+ATOM    496  CA  ILE A  73      12.307  44.436   8.491  1.00 26.84           C  
+ATOM    497  C   ILE A  73      10.875  44.625   8.120  1.00 32.47           C  
+ATOM    498  O   ILE A  73      10.133  43.680   7.941  1.00 49.38           O  
+ATOM    499  CB  ILE A  73      13.101  43.646   7.465  1.00 32.48           C  
+ATOM    500  CG1 ILE A  73      12.478  42.346   7.165  1.00 34.84           C  
+ATOM    501  CG2 ILE A  73      14.457  43.341   8.059  1.00 39.02           C  
+ATOM    502  CD1 ILE A  73      13.545  41.231   7.219  1.00 10.75           C  
+ATOM    503  N   LEU A  74      10.480  45.885   8.091  1.00 28.72           N  
+ATOM    504  CA  LEU A  74       9.132  46.272   7.758  1.00 32.01           C  
+ATOM    505  C   LEU A  74       9.003  46.593   6.233  1.00 44.21           C  
+ATOM    506  O   LEU A  74       9.806  47.349   5.668  1.00 29.37           O  
+ATOM    507  CB  LEU A  74       8.650  47.526   8.600  1.00 20.24           C  
+ATOM    508  CG  LEU A  74       9.196  47.642  10.030  1.00 19.16           C  
+ATOM    509  CD1 LEU A  74      10.650  48.088  10.035  1.00 12.06           C  
+ATOM    510  CD2 LEU A  74       8.372  48.647  10.812  1.00 35.20           C  
+ATOM    511  N   ASP A  75       7.966  46.066   5.598  1.00 26.32           N  
+ATOM    512  CA  ASP A  75       7.745  46.362   4.216  1.00 33.94           C  
+ATOM    513  C   ASP A  75       7.042  47.662   4.038  1.00 42.26           C  
+ATOM    514  O   ASP A  75       5.905  47.827   4.472  1.00 45.09           O  
+ATOM    515  CB  ASP A  75       7.016  45.241   3.442  1.00 45.41           C  
+ATOM    516  CG  ASP A  75       6.010  45.767   2.415  1.00 38.48           C  
+ATOM    517  OD1 ASP A  75       6.250  46.677   1.597  1.00 57.55           O  
+ATOM    518  OD2 ASP A  75       4.836  45.203   2.541  1.00100.00           O  
+ATOM    519  N   LYS A  76       7.666  48.516   3.242  1.00 44.59           N  
+ATOM    520  CA  LYS A  76       7.140  49.812   2.939  1.00 32.90           C  
+ATOM    521  C   LYS A  76       5.652  49.783   2.550  1.00 29.88           C  
+ATOM    522  O   LYS A  76       4.857  50.675   2.893  1.00 23.02           O  
+ATOM    523  CB  LYS A  76       8.002  50.582   1.939  1.00 22.07           C  
+ATOM    524  CG  LYS A  76       9.477  50.698   2.404  1.00 40.81           C  
+ATOM    525  CD  LYS A  76      10.187  51.939   1.920  1.00 13.33           C  
+ATOM    526  CE  LYS A  76      11.192  51.741   0.816  1.00 42.58           C  
+ATOM    527  NZ  LYS A  76      12.199  52.839   0.734  1.00 35.53           N  
+ATOM    528  N   GLN A  77       5.234  48.785   1.887  1.00 16.54           N  
+ATOM    529  CA  GLN A  77       3.833  48.824   1.494  1.00 31.83           C  
+ATOM    530  C   GLN A  77       2.794  48.355   2.499  1.00 24.22           C  
+ATOM    531  O   GLN A  77       1.609  48.607   2.328  1.00 55.54           O  
+ATOM    532  CB  GLN A  77       3.585  48.306   0.106  1.00 50.38           C  
+ATOM    533  CG  GLN A  77       4.130  49.262  -0.958  1.00 96.56           C  
+ATOM    534  CD  GLN A  77       4.224  48.639  -2.346  1.00100.00           C  
+ATOM    535  OE1 GLN A  77       4.123  47.395  -2.524  1.00 77.19           O  
+ATOM    536  NE2 GLN A  77       4.440  49.496  -3.344  1.00100.00           N  
+ATOM    537  N   LYS A  78       3.209  47.657   3.523  1.00 48.24           N  
+ATOM    538  CA  LYS A  78       2.246  47.197   4.490  1.00 54.89           C  
+ATOM    539  C   LYS A  78       2.056  48.218   5.605  1.00 71.10           C  
+ATOM    540  O   LYS A  78       1.053  48.217   6.304  1.00 92.83           O  
+ATOM    541  CB  LYS A  78       2.557  45.794   5.022  1.00 60.26           C  
+ATOM    542  CG  LYS A  78       1.334  44.881   5.004  1.00 57.04           C  
+ATOM    543  CD  LYS A  78       1.598  43.493   5.565  1.00 72.97           C  
+ATOM    544  CE  LYS A  78       0.328  42.655   5.718  1.00 66.30           C  
+ATOM    545  NZ  LYS A  78      -0.606  43.206   6.720  1.00100.00           N  
+ATOM    546  N   VAL A  79       3.032  49.117   5.737  1.00 61.58           N  
+ATOM    547  CA  VAL A  79       2.996  50.143   6.780  1.00 62.84           C  
+ATOM    548  C   VAL A  79       2.177  51.359   6.388  1.00 60.04           C  
+ATOM    549  O   VAL A  79       1.850  52.218   7.216  1.00 29.36           O  
+ATOM    550  CB  VAL A  79       4.406  50.527   7.315  1.00 47.28           C  
+ATOM    551  CG1 VAL A  79       5.336  49.301   7.336  1.00 39.44           C  
+ATOM    552  CG2 VAL A  79       5.026  51.669   6.507  1.00 28.22           C  
+ATOM    553  N   VAL A  80       1.837  51.426   5.135  1.00 62.75           N  
+ATOM    554  CA  VAL A  80       1.066  52.518   4.676  1.00 63.59           C  
+ATOM    555  C   VAL A  80      -0.415  52.249   4.775  1.00 86.34           C  
+ATOM    556  O   VAL A  80      -1.172  53.068   5.304  1.00100.00           O  
+ATOM    557  CB  VAL A  80       1.496  52.963   3.330  1.00 57.14           C  
+ATOM    558  CG1 VAL A  80       0.979  54.364   3.079  1.00 49.22           C  
+ATOM    559  CG2 VAL A  80       3.026  52.945   3.279  1.00 55.98           C  
+ATOM    560  N   LYS A  81      -0.820  51.067   4.326  1.00 62.64           N  
+ATOM    561  CA  LYS A  81      -2.205  50.680   4.436  1.00 68.94           C  
+ATOM    562  C   LYS A  81      -2.739  50.955   5.876  1.00 70.07           C  
+ATOM    563  O   LYS A  81      -3.960  51.213   6.102  1.00 45.80           O  
+ATOM    564  CB  LYS A  81      -2.384  49.222   4.043  1.00 79.19           C  
+ATOM    565  CG  LYS A  81      -1.961  48.931   2.598  1.00100.00           C  
+ATOM    566  CD  LYS A  81      -2.156  47.458   2.159  1.00100.00           C  
+ATOM    567  CE  LYS A  81      -2.133  47.252   0.626  1.00100.00           C  
+ATOM    568  NZ  LYS A  81      -3.350  47.749  -0.064  1.00100.00           N  
+ATOM    569  N   LEU A  82      -1.789  50.925   6.841  1.00 71.55           N  
+ATOM    570  CA  LEU A  82      -2.076  51.173   8.257  1.00 82.96           C  
+ATOM    571  C   LEU A  82      -1.444  52.472   8.726  1.00 93.87           C  
+ATOM    572  O   LEU A  82      -1.168  52.645   9.935  1.00 81.87           O  
+ATOM    573  CB  LEU A  82      -1.570  50.032   9.146  1.00 78.65           C  
+ATOM    574  CG  LEU A  82      -0.961  48.907   8.353  1.00 63.52           C  
+ATOM    575  CD1 LEU A  82       0.363  48.503   8.997  1.00 64.90           C  
+ATOM    576  CD2 LEU A  82      -1.932  47.712   8.298  1.00 38.78           C  
+ATOM    577  N   LYS A  83      -1.080  53.329   7.746  1.00 89.17           N  
+ATOM    578  CA  LYS A  83      -0.423  54.629   7.987  1.00 88.87           C  
+ATOM    579  C   LYS A  83       0.664  54.588   9.069  1.00 81.42           C  
+ATOM    580  O   LYS A  83       1.240  55.629   9.406  1.00 92.88           O  
+ATOM    581  CB  LYS A  83      -1.406  55.783   8.230  1.00 90.07           C  
+ATOM    582  CG  LYS A  83      -2.546  55.825   7.233  1.00 83.83           C  
+ATOM    583  CD  LYS A  83      -3.857  55.286   7.811  1.00100.00           C  
+ATOM    584  CE  LYS A  83      -5.094  55.642   6.974  1.00100.00           C  
+ATOM    585  NZ  LYS A  83      -6.364  55.148   7.549  1.00100.00           N  
+ATOM    586  N   GLN A  84       0.998  53.356   9.561  1.00 43.40           N  
+ATOM    587  CA  GLN A  84       1.996  53.098  10.620  1.00 42.56           C  
+ATOM    588  C   GLN A  84       3.318  53.865  10.446  1.00 53.91           C  
+ATOM    589  O   GLN A  84       4.292  53.597  11.144  1.00 50.95           O  
+ATOM    590  CB  GLN A  84       2.289  51.603  10.725  1.00 37.03           C  
+ATOM    591  CG  GLN A  84       1.078  50.767  11.104  1.00 69.92           C  
+ATOM    592  CD  GLN A  84       0.978  50.617  12.589  1.00100.00           C  
+ATOM    593  OE1 GLN A  84       0.670  49.530  13.106  1.00100.00           O  
+ATOM    594  NE2 GLN A  84       1.341  51.683  13.290  1.00 85.19           N  
+ATOM    595  N   ILE A  85       3.345  54.771   9.461  1.00 53.90           N  
+ATOM    596  CA  ILE A  85       4.485  55.605   9.139  1.00 52.55           C  
+ATOM    597  C   ILE A  85       4.830  56.485  10.258  1.00 70.76           C  
+ATOM    598  O   ILE A  85       5.956  56.489  10.770  1.00 83.95           O  
+ATOM    599  CB  ILE A  85       4.155  56.526   8.000  1.00 42.84           C  
+ATOM    600  CG1 ILE A  85       3.118  55.934   7.070  1.00 40.91           C  
+ATOM    601  CG2 ILE A  85       5.417  56.894   7.242  1.00 37.31           C  
+ATOM    602  CD1 ILE A  85       3.161  56.608   5.691  1.00 27.40           C  
+ATOM    603  N   GLU A  86       3.865  57.308  10.592  1.00 46.70           N  
+ATOM    604  CA  GLU A  86       4.029  58.247  11.631  1.00 54.59           C  
+ATOM    605  C   GLU A  86       4.793  57.578  12.727  1.00 50.54           C  
+ATOM    606  O   GLU A  86       5.779  58.093  13.210  1.00 71.57           O  
+ATOM    607  CB  GLU A  86       2.640  58.816  12.119  1.00 64.24           C  
+ATOM    608  CG  GLU A  86       1.456  58.628  11.072  1.00100.00           C  
+ATOM    609  CD  GLU A  86       1.314  59.722   9.971  1.00100.00           C  
+ATOM    610  OE1 GLU A  86       2.279  60.337   9.443  1.00 34.19           O  
+ATOM    611  OE2 GLU A  86       0.050  59.860   9.567  1.00100.00           O  
+ATOM    612  N   HIS A  87       4.396  56.340  12.989  1.00 32.41           N  
+ATOM    613  CA  HIS A  87       4.996  55.522  13.971  1.00 24.42           C  
+ATOM    614  C   HIS A  87       6.374  55.067  13.579  1.00 38.69           C  
+ATOM    615  O   HIS A  87       7.370  55.624  14.038  1.00 49.18           O  
+ATOM    616  CB  HIS A  87       4.089  54.336  14.337  1.00 27.80           C  
+ATOM    617  CG  HIS A  87       2.850  54.702  15.179  1.00 43.96           C  
+ATOM    618  ND1 HIS A  87       1.684  53.906  15.151  1.00 44.44           N  
+ATOM    619  CD2 HIS A  87       2.627  55.731  16.094  1.00 46.90           C  
+ATOM    620  CE1 HIS A  87       0.804  54.454  16.024  1.00 45.82           C  
+ATOM    621  NE2 HIS A  87       1.335  55.548  16.599  1.00 40.51           N  
+ATOM    622  N   THR A  88       6.421  54.116  12.641  1.00 40.69           N  
+ATOM    623  CA  THR A  88       7.663  53.503  12.100  1.00 29.35           C  
+ATOM    624  C   THR A  88       8.878  54.433  12.053  1.00 30.64           C  
+ATOM    625  O   THR A  88       9.989  54.004  11.850  1.00 40.54           O  
+ATOM    626  CB  THR A  88       7.409  52.923  10.712  1.00 34.14           C  
+ATOM    627  OG1 THR A  88       6.240  52.114  10.734  1.00 50.17           O  
+ATOM    628  CG2 THR A  88       8.621  52.102  10.251  1.00 25.60           C  
+ATOM    629  N   LEU A  89       8.646  55.685  12.168  1.00 26.71           N  
+ATOM    630  CA  LEU A  89       9.673  56.639  12.056  1.00 46.48           C  
+ATOM    631  C   LEU A  89      10.260  57.037  13.385  1.00 44.59           C  
+ATOM    632  O   LEU A  89      11.464  57.340  13.489  1.00 35.39           O  
+ATOM    633  CB  LEU A  89       9.198  57.857  11.229  1.00 63.63           C  
+ATOM    634  CG  LEU A  89       8.986  57.525   9.740  1.00 46.41           C  
+ATOM    635  CD1 LEU A  89       7.719  58.170   9.252  1.00 38.12           C  
+ATOM    636  CD2 LEU A  89      10.146  58.025   8.939  1.00  7.60           C  
+ATOM    637  N   ASN A  90       9.419  57.067  14.415  1.00 38.91           N  
+ATOM    638  CA  ASN A  90       9.916  57.402  15.747  1.00 42.00           C  
+ATOM    639  C   ASN A  90      10.554  56.229  16.429  1.00 58.80           C  
+ATOM    640  O   ASN A  90      11.471  56.408  17.251  1.00 58.82           O  
+ATOM    641  CB  ASN A  90       8.885  58.024  16.613  1.00 28.76           C  
+ATOM    642  CG  ASN A  90       7.573  57.685  16.106  1.00 71.87           C  
+ATOM    643  OD1 ASN A  90       6.826  56.973  16.757  1.00100.00           O  
+ATOM    644  ND2 ASN A  90       7.367  58.003  14.838  1.00 70.09           N  
+ATOM    645  N   GLU A  91      10.091  54.994  16.091  1.00 50.68           N  
+ATOM    646  CA  GLU A  91      10.751  53.832  16.667  1.00 38.90           C  
+ATOM    647  C   GLU A  91      12.226  53.878  16.318  1.00 48.14           C  
+ATOM    648  O   GLU A  91      13.098  53.624  17.165  1.00 54.94           O  
+ATOM    649  CB  GLU A  91      10.103  52.440  16.382  1.00 34.32           C  
+ATOM    650  CG  GLU A  91      10.838  51.310  17.177  1.00 51.57           C  
+ATOM    651  CD  GLU A  91      10.481  49.908  16.776  1.00 51.75           C  
+ATOM    652  OE1 GLU A  91       9.733  49.654  15.844  1.00 36.50           O  
+ATOM    653  OE2 GLU A  91      11.088  48.982  17.546  1.00 41.53           O  
+ATOM    654  N   LYS A  92      12.512  54.313  15.073  1.00 41.86           N  
+ATOM    655  CA  LYS A  92      13.881  54.510  14.665  1.00 40.46           C  
+ATOM    656  C   LYS A  92      14.472  55.681  15.465  1.00 32.71           C  
+ATOM    657  O   LYS A  92      15.456  55.546  16.211  1.00 32.85           O  
+ATOM    658  CB  LYS A  92      14.031  54.756  13.126  1.00 59.52           C  
+ATOM    659  CG  LYS A  92      15.515  54.749  12.617  1.00 58.87           C  
+ATOM    660  CD  LYS A  92      15.807  55.718  11.430  1.00 50.41           C  
+ATOM    661  CE  LYS A  92      15.956  57.201  11.837  1.00 47.37           C  
+ATOM    662  NZ  LYS A  92      16.927  57.966  11.010  1.00 44.79           N  
+ATOM    663  N   ARG A  93      13.810  56.827  15.364  1.00 35.84           N  
+ATOM    664  CA  ARG A  93      14.302  58.023  16.003  1.00 35.51           C  
+ATOM    665  C   ARG A  93      14.561  57.855  17.490  1.00 36.94           C  
+ATOM    666  O   ARG A  93      15.474  58.459  18.044  1.00 31.82           O  
+ATOM    667  CB  ARG A  93      13.479  59.262  15.660  1.00 33.40           C  
+ATOM    668  CG  ARG A  93      14.282  60.564  15.789  1.00 10.83           C  
+ATOM    669  CD  ARG A  93      13.546  61.767  15.167  1.00 20.70           C  
+ATOM    670  NE  ARG A  93      14.360  62.994  15.085  1.00100.00           N  
+ATOM    671  CZ  ARG A  93      14.026  64.168  15.651  1.00100.00           C  
+ATOM    672  NH1 ARG A  93      12.948  64.305  16.407  1.00100.00           N  
+ATOM    673  NH2 ARG A  93      14.866  65.198  15.523  1.00100.00           N  
+ATOM    674  N   ILE A  94      13.776  56.981  18.117  1.00 35.92           N  
+ATOM    675  CA  ILE A  94      13.895  56.706  19.539  1.00 23.55           C  
+ATOM    676  C   ILE A  94      15.067  55.793  19.863  1.00 34.49           C  
+ATOM    677  O   ILE A  94      15.966  56.175  20.573  1.00 30.99           O  
+ATOM    678  CB  ILE A  94      12.641  56.122  20.055  1.00 20.03           C  
+ATOM    679  CG1 ILE A  94      11.543  57.166  20.078  1.00 17.19           C  
+ATOM    680  CG2 ILE A  94      12.870  55.541  21.429  1.00 48.76           C  
+ATOM    681  CD1 ILE A  94      10.150  56.534  20.139  1.00  3.73           C  
+ATOM    682  N   LEU A  95      15.027  54.559  19.330  1.00 25.83           N  
+ATOM    683  CA  LEU A  95      16.114  53.583  19.534  1.00 15.21           C  
+ATOM    684  C   LEU A  95      17.404  54.181  19.236  1.00 31.75           C  
+ATOM    685  O   LEU A  95      18.429  53.754  19.768  1.00 34.95           O  
+ATOM    686  CB  LEU A  95      15.988  52.367  18.598  1.00 21.83           C  
+ATOM    687  CG  LEU A  95      15.162  51.243  19.159  1.00 46.11           C  
+ATOM    688  CD1 LEU A  95      14.810  51.525  20.630  1.00 67.20           C  
+ATOM    689  CD2 LEU A  95      13.908  51.071  18.335  1.00 34.40           C  
+ATOM    690  N   GLN A  96      17.367  55.076  18.224  1.00 38.39           N  
+ATOM    691  CA  GLN A  96      18.536  55.784  17.715  1.00 40.95           C  
+ATOM    692  C   GLN A  96      19.084  56.807  18.742  1.00 63.47           C  
+ATOM    693  O   GLN A  96      20.277  57.122  18.741  1.00 37.55           O  
+ATOM    694  CB  GLN A  96      18.265  56.408  16.264  1.00 22.85           C  
+ATOM    695  CG  GLN A  96      18.964  57.792  15.966  1.00 23.36           C  
+ATOM    696  CD  GLN A  96      18.163  59.041  16.485  1.00 95.76           C  
+ATOM    697  OE1 GLN A  96      18.726  59.888  17.194  1.00 96.21           O  
+ATOM    698  NE2 GLN A  96      16.847  59.187  16.080  1.00  6.42           N  
+ATOM    699  N   ALA A  97      18.181  57.300  19.639  1.00 52.40           N  
+ATOM    700  CA  ALA A  97      18.553  58.281  20.664  1.00 47.25           C  
+ATOM    701  C   ALA A  97      18.479  57.715  22.067  1.00 62.81           C  
+ATOM    702  O   ALA A  97      19.296  58.053  22.936  1.00 83.43           O  
+ATOM    703  CB  ALA A  97      17.735  59.565  20.535  1.00 51.01           C  
+ATOM    704  N   VAL A  98      17.493  56.847  22.290  1.00 60.48           N  
+ATOM    705  CA  VAL A  98      17.345  56.220  23.578  1.00 53.36           C  
+ATOM    706  C   VAL A  98      18.680  55.604  23.981  1.00 45.49           C  
+ATOM    707  O   VAL A  98      19.503  55.377  23.139  1.00 34.53           O  
+ATOM    708  CB  VAL A  98      16.193  55.220  23.591  1.00 46.94           C  
+ATOM    709  CG1 VAL A  98      16.643  53.847  23.116  1.00 46.54           C  
+ATOM    710  CG2 VAL A  98      15.617  55.144  24.980  1.00 49.09           C  
+ATOM    711  N   ASN A  99      18.947  55.478  25.281  1.00 40.00           N  
+ATOM    712  CA  ASN A  99      20.234  54.907  25.739  1.00 31.79           C  
+ATOM    713  C   ASN A  99      20.214  54.502  27.226  1.00 53.55           C  
+ATOM    714  O   ASN A  99      19.975  55.316  28.138  1.00 49.50           O  
+ATOM    715  CB  ASN A  99      21.480  55.657  25.232  1.00 17.29           C  
+ATOM    716  CG  ASN A  99      22.778  55.343  25.948  1.00 44.74           C  
+ATOM    717  OD1 ASN A  99      22.931  54.295  26.608  1.00 51.60           O  
+ATOM    718  ND2 ASN A  99      23.725  56.275  25.827  1.00100.00           N  
+ATOM    719  N   PHE A 100      20.345  53.186  27.433  1.00 52.87           N  
+ATOM    720  CA  PHE A 100      20.125  52.602  28.689  1.00 40.08           C  
+ATOM    721  C   PHE A 100      20.359  51.068  28.641  1.00 31.48           C  
+ATOM    722  O   PHE A 100      20.083  50.399  27.663  1.00 51.70           O  
+ATOM    723  CB  PHE A 100      18.665  52.879  29.054  1.00 58.99           C  
+ATOM    724  CG  PHE A 100      18.315  52.849  30.494  1.00 62.67           C  
+ATOM    725  CD1 PHE A 100      18.779  53.825  31.374  1.00 58.43           C  
+ATOM    726  CD2 PHE A 100      17.381  51.933  30.969  1.00 46.92           C  
+ATOM    727  CE1 PHE A 100      18.406  53.839  32.711  1.00 55.77           C  
+ATOM    728  CE2 PHE A 100      16.985  51.929  32.302  1.00 46.06           C  
+ATOM    729  CZ  PHE A 100      17.506  52.881  33.172  1.00 33.89           C  
+ATOM    730  N   PRO A 101      20.814  50.548  29.734  1.00 46.84           N  
+ATOM    731  CA  PRO A 101      21.137  49.173  29.862  1.00 51.91           C  
+ATOM    732  C   PRO A 101      20.043  48.220  29.485  1.00 40.31           C  
+ATOM    733  O   PRO A 101      20.227  47.259  28.809  1.00 66.67           O  
+ATOM    734  CB  PRO A 101      21.467  48.933  31.366  1.00 37.32           C  
+ATOM    735  CG  PRO A 101      21.603  50.319  32.018  1.00 42.04           C  
+ATOM    736  CD  PRO A 101      21.105  51.313  30.974  1.00 54.13           C  
+ATOM    737  N   PHE A 102      18.911  48.446  30.038  1.00 29.06           N  
+ATOM    738  CA  PHE A 102      17.828  47.552  29.870  1.00 24.73           C  
+ATOM    739  C   PHE A 102      17.073  47.717  28.560  1.00 47.31           C  
+ATOM    740  O   PHE A 102      16.094  47.024  28.273  1.00 54.92           O  
+ATOM    741  CB  PHE A 102      16.927  47.499  31.142  1.00 31.33           C  
+ATOM    742  CG  PHE A 102      17.786  47.411  32.407  1.00 50.40           C  
+ATOM    743  CD1 PHE A 102      18.838  46.501  32.495  1.00 78.42           C  
+ATOM    744  CD2 PHE A 102      17.565  48.246  33.501  1.00 37.83           C  
+ATOM    745  CE1 PHE A 102      19.651  46.416  33.626  1.00 55.34           C  
+ATOM    746  CE2 PHE A 102      18.368  48.194  34.635  1.00 32.60           C  
+ATOM    747  CZ  PHE A 102      19.412  47.274  34.690  1.00 39.48           C  
+ATOM    748  N   LEU A 103      17.591  48.645  27.732  1.00 32.94           N  
+ATOM    749  CA  LEU A 103      17.026  48.898  26.403  1.00 16.50           C  
+ATOM    750  C   LEU A 103      17.810  48.172  25.367  1.00 30.44           C  
+ATOM    751  O   LEU A 103      19.054  48.113  25.442  1.00 20.79           O  
+ATOM    752  CB  LEU A 103      16.999  50.378  26.064  1.00 29.65           C  
+ATOM    753  CG  LEU A 103      15.692  51.112  26.402  1.00 31.22           C  
+ATOM    754  CD1 LEU A 103      14.986  50.429  27.554  1.00 36.64           C  
+ATOM    755  CD2 LEU A 103      16.037  52.543  26.796  1.00 25.25           C  
+ATOM    756  N   VAL A 104      17.096  47.601  24.412  1.00 55.02           N  
+ATOM    757  CA  VAL A 104      17.714  46.875  23.323  1.00 54.46           C  
+ATOM    758  C   VAL A 104      18.478  47.840  22.426  1.00 36.95           C  
+ATOM    759  O   VAL A 104      17.953  48.890  22.064  1.00 46.61           O  
+ATOM    760  CB  VAL A 104      16.658  46.086  22.526  1.00 46.29           C  
+ATOM    761  CG1 VAL A 104      16.002  46.982  21.483  1.00 34.86           C  
+ATOM    762  CG2 VAL A 104      17.263  44.844  21.882  1.00 34.45           C  
+ATOM    763  N   LYS A 105      19.760  47.502  22.137  1.00  9.46           N  
+ATOM    764  CA  LYS A 105      20.665  48.348  21.256  1.00 27.99           C  
+ATOM    765  C   LYS A 105      20.328  48.262  19.744  1.00 43.09           C  
+ATOM    766  O   LYS A 105      20.262  47.175  19.163  1.00 53.57           O  
+ATOM    767  CB  LYS A 105      22.162  47.966  21.393  1.00 49.38           C  
+ATOM    768  CG  LYS A 105      22.981  48.761  22.412  1.00 36.53           C  
+ATOM    769  CD  LYS A 105      23.524  47.877  23.527  1.00 49.82           C  
+ATOM    770  CE  LYS A 105      24.893  48.302  24.015  1.00 75.01           C  
+ATOM    771  NZ  LYS A 105      25.947  48.061  23.016  1.00 61.28           N  
+ATOM    772  N   LEU A 106      20.234  49.434  19.102  1.00 24.83           N  
+ATOM    773  CA  LEU A 106      20.067  49.521  17.692  1.00 12.86           C  
+ATOM    774  C   LEU A 106      21.408  49.738  17.077  1.00 19.94           C  
+ATOM    775  O   LEU A 106      22.110  50.605  17.464  1.00 19.46           O  
+ATOM    776  CB  LEU A 106      19.158  50.631  17.290  1.00 16.73           C  
+ATOM    777  CG  LEU A 106      19.133  50.720  15.811  1.00  6.92           C  
+ATOM    778  CD1 LEU A 106      18.915  49.326  15.262  1.00  8.91           C  
+ATOM    779  CD2 LEU A 106      18.034  51.633  15.366  1.00  6.18           C  
+ATOM    780  N   GLU A 107      21.768  48.929  16.142  1.00 21.91           N  
+ATOM    781  CA  GLU A 107      23.067  49.020  15.561  1.00 14.62           C  
+ATOM    782  C   GLU A 107      23.156  49.717  14.204  1.00 40.23           C  
+ATOM    783  O   GLU A 107      24.121  50.496  13.933  1.00 24.44           O  
+ATOM    784  CB  GLU A 107      23.656  47.677  15.525  1.00 15.44           C  
+ATOM    785  CG  GLU A 107      24.128  47.327  16.885  1.00 13.84           C  
+ATOM    786  CD  GLU A 107      25.445  47.987  17.149  1.00100.00           C  
+ATOM    787  OE1 GLU A 107      26.313  48.094  16.296  1.00 81.94           O  
+ATOM    788  OE2 GLU A 107      25.498  48.574  18.315  1.00100.00           O  
+ATOM    789  N   PHE A 108      22.151  49.438  13.351  1.00 39.75           N  
+ATOM    790  CA  PHE A 108      22.111  49.971  12.009  1.00 17.32           C  
+ATOM    791  C   PHE A 108      20.693  50.192  11.495  1.00 26.32           C  
+ATOM    792  O   PHE A 108      19.758  49.473  11.849  1.00 34.13           O  
+ATOM    793  CB  PHE A 108      22.761  48.974  11.046  1.00 26.22           C  
+ATOM    794  CG  PHE A 108      24.072  48.383  11.495  1.00 29.73           C  
+ATOM    795  CD1 PHE A 108      24.120  47.256  12.316  1.00 48.26           C  
+ATOM    796  CD2 PHE A 108      25.273  48.909  11.022  1.00 26.70           C  
+ATOM    797  CE1 PHE A 108      25.346  46.708  12.699  1.00 60.77           C  
+ATOM    798  CE2 PHE A 108      26.507  48.374  11.393  1.00 33.31           C  
+ATOM    799  CZ  PHE A 108      26.538  47.265  12.236  1.00 32.96           C  
+ATOM    800  N   SER A 109      20.573  51.087  10.546  1.00 30.07           N  
+ATOM    801  CA  SER A 109      19.308  51.291   9.864  1.00 16.92           C  
+ATOM    802  C   SER A 109      19.518  51.744   8.454  1.00 47.88           C  
+ATOM    803  O   SER A 109      20.219  52.715   8.186  1.00 52.53           O  
+ATOM    804  CB  SER A 109      18.234  52.125  10.593  1.00 13.64           C  
+ATOM    805  OG  SER A 109      18.810  53.123  11.395  1.00 46.25           O  
+ATOM    806  N   PHE A 110      18.957  50.987   7.547  1.00 39.24           N  
+ATOM    807  CA  PHE A 110      19.020  51.270   6.137  1.00 29.00           C  
+ATOM    808  C   PHE A 110      17.731  50.913   5.527  1.00 30.38           C  
+ATOM    809  O   PHE A 110      16.930  50.232   6.127  1.00 29.46           O  
+ATOM    810  CB  PHE A 110      20.132  50.477   5.432  1.00 24.11           C  
+ATOM    811  CG  PHE A 110      20.140  49.055   5.828  1.00 18.45           C  
+ATOM    812  CD1 PHE A 110      19.324  48.121   5.179  1.00 28.31           C  
+ATOM    813  CD2 PHE A 110      20.926  48.620   6.895  1.00 29.76           C  
+ATOM    814  CE1 PHE A 110      19.274  46.779   5.582  1.00 10.14           C  
+ATOM    815  CE2 PHE A 110      20.907  47.285   7.300  1.00 27.32           C  
+ATOM    816  CZ  PHE A 110      20.076  46.366   6.646  1.00 18.31           C  
+ATOM    817  N   LYS A 111      17.507  51.369   4.346  1.00 35.89           N  
+ATOM    818  CA  LYS A 111      16.300  51.014   3.663  1.00 39.55           C  
+ATOM    819  C   LYS A 111      16.646  50.660   2.307  1.00 42.75           C  
+ATOM    820  O   LYS A 111      17.719  51.030   1.835  1.00 38.10           O  
+ATOM    821  CB  LYS A 111      15.224  52.096   3.705  1.00 57.89           C  
+ATOM    822  CG  LYS A 111      15.783  53.518   3.625  1.00 91.36           C  
+ATOM    823  CD  LYS A 111      14.713  54.581   3.395  1.00 86.21           C  
+ATOM    824  CE  LYS A 111      15.294  55.982   3.262  1.00 60.65           C  
+ATOM    825  NZ  LYS A 111      14.342  56.954   2.707  1.00100.00           N  
+ATOM    826  N   ASP A 112      15.869  49.810   1.744  1.00 43.06           N  
+ATOM    827  CA  ASP A 112      16.068  49.438   0.390  1.00 37.29           C  
+ATOM    828  C   ASP A 112      14.783  49.390  -0.293  1.00 67.06           C  
+ATOM    829  O   ASP A 112      13.800  48.960   0.312  1.00 99.25           O  
+ATOM    830  CB  ASP A 112      17.030  48.251   0.146  1.00 23.87           C  
+ATOM    831  CG  ASP A 112      16.456  46.849   0.192  1.00 54.84           C  
+ATOM    832  OD1 ASP A 112      15.231  46.632   0.383  1.00 14.80           O  
+ATOM    833  OD2 ASP A 112      17.378  45.896   0.075  1.00 54.52           O  
+ATOM    834  N   ASN A 113      14.756  49.966  -1.503  1.00 56.29           N  
+ATOM    835  CA  ASN A 113      13.591  50.065  -2.343  1.00 48.38           C  
+ATOM    836  C   ASN A 113      12.268  49.794  -1.712  1.00 53.92           C  
+ATOM    837  O   ASN A 113      11.347  50.608  -1.771  1.00 54.05           O  
+ATOM    838  CB  ASN A 113      13.701  49.108  -3.579  1.00 66.53           C  
+ATOM    839  CG  ASN A 113      14.449  49.649  -4.769  1.00 84.61           C  
+ATOM    840  OD1 ASN A 113      14.959  48.894  -5.612  1.00100.00           O  
+ATOM    841  ND2 ASN A 113      14.484  50.966  -4.840  1.00 37.03           N  
+ATOM    842  N   SER A 114      12.130  48.551  -1.256  1.00 68.73           N  
+ATOM    843  CA  SER A 114      10.895  47.994  -0.779  1.00 82.36           C  
+ATOM    844  C   SER A 114      10.487  48.029   0.676  1.00 54.43           C  
+ATOM    845  O   SER A 114       9.343  48.275   0.971  1.00 28.86           O  
+ATOM    846  CB  SER A 114      10.806  46.533  -1.289  1.00 94.61           C  
+ATOM    847  OG  SER A 114      11.225  46.478  -2.658  1.00100.00           O  
+ATOM    848  N   ASN A 115      11.399  47.661   1.549  1.00 39.63           N  
+ATOM    849  CA  ASN A 115      11.118  47.586   2.944  1.00 37.24           C  
+ATOM    850  C   ASN A 115      12.233  48.133   3.757  1.00 21.59           C  
+ATOM    851  O   ASN A 115      13.288  48.317   3.235  1.00 12.68           O  
+ATOM    852  CB  ASN A 115      10.767  46.135   3.336  1.00 53.49           C  
+ATOM    853  CG  ASN A 115      11.767  45.160   2.781  1.00 93.57           C  
+ATOM    854  OD1 ASN A 115      12.983  45.489   2.713  1.00 20.15           O  
+ATOM    855  ND2 ASN A 115      11.207  43.999   2.300  1.00 19.20           N  
+ATOM    856  N   LEU A 116      11.918  48.457   5.059  1.00 28.10           N  
+ATOM    857  CA  LEU A 116      12.832  49.126   6.024  1.00 27.24           C  
+ATOM    858  C   LEU A 116      13.497  48.187   6.976  1.00 17.90           C  
+ATOM    859  O   LEU A 116      12.907  47.214   7.413  1.00 38.93           O  
+ATOM    860  CB  LEU A 116      12.071  50.166   6.878  1.00 20.30           C  
+ATOM    861  CG  LEU A 116      11.372  51.246   6.081  1.00 21.63           C  
+ATOM    862  CD1 LEU A 116       9.995  51.502   6.674  1.00 11.17           C  
+ATOM    863  CD2 LEU A 116      12.197  52.518   6.168  1.00 32.90           C  
+ATOM    864  N   TYR A 117      14.668  48.570   7.445  1.00 15.81           N  
+ATOM    865  CA  TYR A 117      15.381  47.717   8.398  1.00 20.27           C  
+ATOM    866  C   TYR A 117      15.997  48.437   9.611  1.00 41.86           C  
+ATOM    867  O   TYR A 117      16.779  49.391   9.487  1.00 42.54           O  
+ATOM    868  CB  TYR A 117      16.469  46.826   7.743  1.00 19.01           C  
+ATOM    869  CG  TYR A 117      16.163  46.325   6.344  1.00 46.64           C  
+ATOM    870  CD1 TYR A 117      16.128  47.178   5.240  1.00 65.14           C  
+ATOM    871  CD2 TYR A 117      16.033  44.965   6.103  1.00 39.86           C  
+ATOM    872  CE1 TYR A 117      15.858  46.697   3.952  1.00 35.55           C  
+ATOM    873  CE2 TYR A 117      15.756  44.468   4.829  1.00  9.68           C  
+ATOM    874  CZ  TYR A 117      15.671  45.333   3.745  1.00 42.53           C  
+ATOM    875  OH  TYR A 117      15.396  44.837   2.463  1.00 48.59           O  
+ATOM    876  N   MET A 118      15.678  47.876  10.776  1.00 40.01           N  
+ATOM    877  CA  MET A 118      16.269  48.184  12.042  1.00 26.42           C  
+ATOM    878  C   MET A 118      16.990  46.899  12.502  1.00 34.06           C  
+ATOM    879  O   MET A 118      16.423  45.765  12.402  1.00 28.94           O  
+ATOM    880  CB  MET A 118      15.224  48.625  13.067  1.00 34.26           C  
+ATOM    881  CG  MET A 118      14.658  50.000  12.798  1.00 44.78           C  
+ATOM    882  SD  MET A 118      13.055  50.234  13.597  1.00 39.93           S  
+ATOM    883  CE  MET A 118      12.260  48.684  13.093  1.00 29.09           C  
+ATOM    884  N   VAL A 119      18.247  47.054  12.920  1.00 23.56           N  
+ATOM    885  CA  VAL A 119      19.117  45.933  13.274  1.00 18.22           C  
+ATOM    886  C   VAL A 119      19.673  46.085  14.670  1.00 27.13           C  
+ATOM    887  O   VAL A 119      20.676  46.796  14.889  1.00 27.37           O  
+ATOM    888  CB  VAL A 119      20.248  45.791  12.207  1.00 25.30           C  
+ATOM    889  CG1 VAL A 119      21.567  45.252  12.780  1.00 15.61           C  
+ATOM    890  CG2 VAL A 119      19.780  44.907  11.046  1.00 25.06           C  
+ATOM    891  N   MET A 120      18.991  45.403  15.634  1.00 26.29           N  
+ATOM    892  CA  MET A 120      19.347  45.444  17.067  1.00 29.97           C  
+ATOM    893  C   MET A 120      20.415  44.455  17.449  1.00 24.38           C  
+ATOM    894  O   MET A 120      20.844  43.658  16.668  1.00 42.90           O  
+ATOM    895  CB  MET A 120      18.122  45.163  17.978  1.00 20.89           C  
+ATOM    896  CG  MET A 120      17.023  46.158  17.883  1.00  4.55           C  
+ATOM    897  SD  MET A 120      15.598  45.429  17.148  1.00 26.83           S  
+ATOM    898  CE  MET A 120      14.276  46.584  17.642  1.00 41.90           C  
+ATOM    899  N   GLU A 121      20.755  44.481  18.714  1.00 29.07           N  
+ATOM    900  CA  GLU A 121      21.595  43.501  19.297  1.00 23.92           C  
+ATOM    901  C   GLU A 121      20.744  42.272  19.560  1.00 15.58           C  
+ATOM    902  O   GLU A 121      19.491  42.373  19.727  1.00 13.51           O  
+ATOM    903  CB  GLU A 121      22.203  43.999  20.572  1.00 25.58           C  
+ATOM    904  CG  GLU A 121      23.490  43.289  20.912  1.00 72.50           C  
+ATOM    905  CD  GLU A 121      23.898  43.542  22.315  1.00 44.87           C  
+ATOM    906  OE1 GLU A 121      24.215  44.660  22.738  1.00 50.03           O  
+ATOM    907  OE2 GLU A 121      23.774  42.481  23.063  1.00100.00           O  
+ATOM    908  N   TYR A 122      21.368  41.112  19.551  1.00 16.91           N  
+ATOM    909  CA  TYR A 122      20.606  39.870  19.633  1.00 20.25           C  
+ATOM    910  C   TYR A 122      20.510  39.281  20.973  1.00 36.22           C  
+ATOM    911  O   TYR A 122      21.425  38.666  21.459  1.00 41.53           O  
+ATOM    912  CB  TYR A 122      20.985  38.848  18.513  1.00  6.08           C  
+ATOM    913  CG  TYR A 122      20.495  37.411  18.696  1.00  3.44           C  
+ATOM    914  CD1 TYR A 122      19.147  37.068  18.529  1.00  9.72           C  
+ATOM    915  CD2 TYR A 122      21.422  36.364  18.808  1.00 15.11           C  
+ATOM    916  CE1 TYR A 122      18.724  35.728  18.589  1.00  2.40           C  
+ATOM    917  CE2 TYR A 122      21.020  35.034  18.964  1.00  2.31           C  
+ATOM    918  CZ  TYR A 122      19.655  34.717  18.841  1.00  3.54           C  
+ATOM    919  OH  TYR A 122      19.207  33.402  19.052  1.00 19.13           O  
+ATOM    920  N   VAL A 123      19.360  39.442  21.563  1.00 40.10           N  
+ATOM    921  CA  VAL A 123      19.119  38.893  22.856  1.00 34.28           C  
+ATOM    922  C   VAL A 123      18.670  37.485  22.743  1.00 14.96           C  
+ATOM    923  O   VAL A 123      17.498  37.206  22.403  1.00 19.72           O  
+ATOM    924  CB  VAL A 123      18.167  39.755  23.624  1.00 36.13           C  
+ATOM    925  CG1 VAL A 123      18.960  40.891  24.215  1.00 40.03           C  
+ATOM    926  CG2 VAL A 123      17.157  40.351  22.654  1.00 38.51           C  
+ATOM    927  N   ALA A 124      19.635  36.578  22.955  1.00 16.89           N  
+ATOM    928  CA  ALA A 124      19.424  35.095  22.791  1.00 19.19           C  
+ATOM    929  C   ALA A 124      18.438  34.447  23.703  1.00 33.88           C  
+ATOM    930  O   ALA A 124      17.657  33.641  23.266  1.00 47.02           O  
+ATOM    931  CB  ALA A 124      20.724  34.339  22.907  1.00 14.20           C  
+ATOM    932  N   GLY A 125      18.615  34.678  25.009  1.00 42.02           N  
+ATOM    933  CA  GLY A 125      17.838  34.038  26.058  1.00 27.35           C  
+ATOM    934  C   GLY A 125      16.370  33.795  25.689  1.00 18.58           C  
+ATOM    935  O   GLY A 125      15.693  32.925  26.239  1.00 29.68           O  
+ATOM    936  N   GLY A 126      15.868  34.543  24.813  1.00  9.57           N  
+ATOM    937  CA  GLY A 126      14.521  34.303  24.465  1.00  9.12           C  
+ATOM    938  C   GLY A 126      13.617  35.197  25.194  1.00 14.57           C  
+ATOM    939  O   GLY A 126      13.944  35.690  26.212  1.00 29.59           O  
+ATOM    940  N   GLU A 127      12.464  35.404  24.607  1.00 26.02           N  
+ATOM    941  CA  GLU A 127      11.423  36.276  25.108  1.00 15.80           C  
+ATOM    942  C   GLU A 127      10.827  35.812  26.466  1.00 15.79           C  
+ATOM    943  O   GLU A 127      10.692  34.647  26.718  1.00 33.84           O  
+ATOM    944  CB  GLU A 127      10.330  36.512  24.034  1.00 20.47           C  
+ATOM    945  CG  GLU A 127       9.473  35.262  23.692  1.00 49.29           C  
+ATOM    946  CD  GLU A 127       8.219  35.565  22.859  1.00 26.67           C  
+ATOM    947  OE1 GLU A 127       7.249  36.171  23.296  1.00100.00           O  
+ATOM    948  OE2 GLU A 127       8.283  35.080  21.626  1.00 57.76           O  
+ATOM    949  N   MET A 128      10.464  36.754  27.328  1.00 18.44           N  
+ATOM    950  CA  MET A 128      10.000  36.391  28.642  1.00 19.34           C  
+ATOM    951  C   MET A 128       8.761  35.582  28.667  1.00 13.42           C  
+ATOM    952  O   MET A 128       8.651  34.607  29.433  1.00 40.63           O  
+ATOM    953  CB  MET A 128       9.857  37.551  29.573  1.00 25.74           C  
+ATOM    954  CG  MET A 128       9.409  37.087  30.943  1.00 22.19           C  
+ATOM    955  SD  MET A 128       8.621  38.369  31.859  1.00 20.20           S  
+ATOM    956  CE  MET A 128      10.077  39.475  32.062  1.00  1.00           C  
+ATOM    957  N   PHE A 129       7.781  36.063  27.946  1.00 19.34           N  
+ATOM    958  CA  PHE A 129       6.475  35.424  27.842  1.00 23.75           C  
+ATOM    959  C   PHE A 129       6.553  33.925  27.883  1.00 40.26           C  
+ATOM    960  O   PHE A 129       5.660  33.261  28.365  1.00 42.41           O  
+ATOM    961  CB  PHE A 129       5.778  35.854  26.544  1.00 29.84           C  
+ATOM    962  CG  PHE A 129       4.613  34.984  26.142  1.00 23.28           C  
+ATOM    963  CD1 PHE A 129       4.814  33.791  25.452  1.00 29.73           C  
+ATOM    964  CD2 PHE A 129       3.295  35.379  26.411  1.00 42.55           C  
+ATOM    965  CE1 PHE A 129       3.727  33.000  25.057  1.00 42.54           C  
+ATOM    966  CE2 PHE A 129       2.195  34.611  26.007  1.00 36.50           C  
+ATOM    967  CZ  PHE A 129       2.418  33.422  25.319  1.00 27.54           C  
+ATOM    968  N   SER A 130       7.618  33.392  27.337  1.00 32.17           N  
+ATOM    969  CA  SER A 130       7.768  31.970  27.246  1.00 22.24           C  
+ATOM    970  C   SER A 130       8.286  31.300  28.513  1.00 21.95           C  
+ATOM    971  O   SER A 130       7.722  30.341  28.967  1.00 21.77           O  
+ATOM    972  CB  SER A 130       8.562  31.581  26.041  1.00 12.78           C  
+ATOM    973  OG  SER A 130       9.958  31.712  26.305  1.00 84.79           O  
+ATOM    974  N   HIS A 131       9.398  31.764  29.034  1.00 24.62           N  
+ATOM    975  CA  HIS A 131       9.898  31.164  30.236  1.00 21.18           C  
+ATOM    976  C   HIS A 131       8.793  31.151  31.255  1.00 15.12           C  
+ATOM    977  O   HIS A 131       8.395  30.118  31.796  1.00 14.24           O  
+ATOM    978  CB  HIS A 131      11.122  31.876  30.724  1.00 11.46           C  
+ATOM    979  CG  HIS A 131      12.231  31.864  29.719  1.00 26.04           C  
+ATOM    980  ND1 HIS A 131      12.989  30.726  29.495  1.00 49.79           N  
+ATOM    981  CD2 HIS A 131      12.726  32.847  28.921  1.00 44.54           C  
+ATOM    982  CE1 HIS A 131      13.932  31.039  28.579  1.00 42.38           C  
+ATOM    983  NE2 HIS A 131      13.805  32.304  28.221  1.00 42.96           N  
+ATOM    984  N   LEU A 132       8.166  32.253  31.346  1.00 17.05           N  
+ATOM    985  CA  LEU A 132       7.040  32.387  32.189  1.00  5.86           C  
+ATOM    986  C   LEU A 132       6.046  31.240  31.988  1.00  5.12           C  
+ATOM    987  O   LEU A 132       5.585  30.675  32.912  1.00 30.95           O  
+ATOM    988  CB  LEU A 132       6.361  33.797  31.964  1.00  5.13           C  
+ATOM    989  CG  LEU A 132       4.983  33.963  32.637  1.00 14.70           C  
+ATOM    990  CD1 LEU A 132       5.082  33.666  34.109  1.00 13.13           C  
+ATOM    991  CD2 LEU A 132       4.435  35.397  32.412  1.00  1.00           C  
+ATOM    992  N   ARG A 133       5.656  30.968  30.748  1.00 39.04           N  
+ATOM    993  CA  ARG A 133       4.650  29.921  30.502  1.00 34.70           C  
+ATOM    994  C   ARG A 133       5.194  28.534  30.720  1.00 26.82           C  
+ATOM    995  O   ARG A 133       4.442  27.548  31.065  1.00 33.34           O  
+ATOM    996  CB  ARG A 133       4.028  30.023  29.136  1.00 31.75           C  
+ATOM    997  CG  ARG A 133       3.348  31.339  28.897  1.00 58.22           C  
+ATOM    998  CD  ARG A 133       1.886  31.357  29.286  1.00  1.00           C  
+ATOM    999  NE  ARG A 133       1.460  32.714  29.754  1.00100.00           N  
+ATOM   1000  CZ  ARG A 133       0.683  33.600  29.060  1.00100.00           C  
+ATOM   1001  NH1 ARG A 133       0.165  33.325  27.845  1.00 84.58           N  
+ATOM   1002  NH2 ARG A 133       0.407  34.791  29.617  1.00 47.00           N  
+ATOM   1003  N   ARG A 134       6.472  28.412  30.478  1.00  2.39           N  
+ATOM   1004  CA  ARG A 134       7.100  27.164  30.689  1.00 35.24           C  
+ATOM   1005  C   ARG A 134       7.157  26.870  32.186  1.00 51.87           C  
+ATOM   1006  O   ARG A 134       6.490  25.940  32.696  1.00 30.23           O  
+ATOM   1007  CB  ARG A 134       8.482  27.057  30.049  1.00 25.17           C  
+ATOM   1008  CG  ARG A 134       8.771  25.616  29.668  1.00 41.76           C  
+ATOM   1009  CD  ARG A 134      10.226  25.258  29.657  1.00 36.39           C  
+ATOM   1010  NE  ARG A 134      10.969  25.827  30.766  1.00 94.35           N  
+ATOM   1011  CZ  ARG A 134      11.607  26.984  30.693  1.00100.00           C  
+ATOM   1012  NH1 ARG A 134      11.598  27.719  29.570  1.00 64.21           N  
+ATOM   1013  NH2 ARG A 134      12.292  27.420  31.765  1.00 51.55           N  
+ATOM   1014  N   ILE A 135       7.878  27.755  32.897  1.00 25.73           N  
+ATOM   1015  CA  ILE A 135       8.063  27.666  34.329  1.00 18.51           C  
+ATOM   1016  C   ILE A 135       6.755  27.582  35.146  1.00 27.26           C  
+ATOM   1017  O   ILE A 135       6.731  26.898  36.165  1.00 34.56           O  
+ATOM   1018  CB  ILE A 135       8.972  28.763  34.850  1.00 26.21           C  
+ATOM   1019  CG1 ILE A 135      10.390  28.485  34.482  1.00 21.55           C  
+ATOM   1020  CG2 ILE A 135       8.873  28.848  36.345  1.00 46.21           C  
+ATOM   1021  CD1 ILE A 135      11.254  29.742  34.560  1.00 42.40           C  
+ATOM   1022  N   GLY A 136       5.698  28.391  34.750  1.00 22.06           N  
+ATOM   1023  CA  GLY A 136       4.309  28.404  35.425  1.00 11.63           C  
+ATOM   1024  C   GLY A 136       3.917  29.771  35.959  1.00  8.73           C  
+ATOM   1025  O   GLY A 136       2.820  30.322  35.655  1.00 20.84           O  
+ATOM   1026  N   ARG A 137       4.835  30.318  36.765  1.00 17.66           N  
+ATOM   1027  CA  ARG A 137       4.709  31.645  37.384  1.00 27.74           C  
+ATOM   1028  C   ARG A 137       6.022  31.986  38.029  1.00 30.38           C  
+ATOM   1029  O   ARG A 137       6.899  31.163  38.083  1.00 12.00           O  
+ATOM   1030  CB  ARG A 137       3.579  31.707  38.410  1.00 38.32           C  
+ATOM   1031  CG  ARG A 137       4.053  31.542  39.880  1.00 63.41           C  
+ATOM   1032  CD  ARG A 137       3.120  30.630  40.719  1.00 57.94           C  
+ATOM   1033  NE  ARG A 137       2.946  31.036  42.124  1.00 78.85           N  
+ATOM   1034  CZ  ARG A 137       3.711  30.634  43.136  1.00 91.10           C  
+ATOM   1035  NH1 ARG A 137       4.758  29.835  42.959  1.00 80.85           N  
+ATOM   1036  NH2 ARG A 137       3.426  31.057  44.367  1.00 84.47           N  
+ATOM   1037  N   PHE A 138       6.177  33.183  38.490  1.00 24.27           N  
+ATOM   1038  CA  PHE A 138       7.422  33.521  39.072  1.00 10.33           C  
+ATOM   1039  C   PHE A 138       7.334  33.661  40.538  1.00 32.19           C  
+ATOM   1040  O   PHE A 138       6.287  34.029  41.095  1.00 24.44           O  
+ATOM   1041  CB  PHE A 138       8.035  34.769  38.455  1.00 14.90           C  
+ATOM   1042  CG  PHE A 138       8.583  34.549  37.087  1.00 30.12           C  
+ATOM   1043  CD1 PHE A 138       9.225  33.359  36.758  1.00 50.54           C  
+ATOM   1044  CD2 PHE A 138       8.596  35.578  36.151  1.00 36.67           C  
+ATOM   1045  CE1 PHE A 138       9.818  33.160  35.504  1.00 52.57           C  
+ATOM   1046  CE2 PHE A 138       9.213  35.410  34.909  1.00 30.16           C  
+ATOM   1047  CZ  PHE A 138       9.828  34.197  34.581  1.00 13.91           C  
+ATOM   1048  N   SER A 139       8.457  33.398  41.165  1.00 24.85           N  
+ATOM   1049  CA  SER A 139       8.576  33.543  42.558  1.00 23.20           C  
+ATOM   1050  C   SER A 139       8.775  35.008  42.873  1.00 42.37           C  
+ATOM   1051  O   SER A 139       9.679  35.649  42.307  1.00 39.22           O  
+ATOM   1052  CB  SER A 139       9.698  32.665  43.139  1.00 20.11           C  
+ATOM   1053  OG  SER A 139      10.905  33.403  43.246  1.00 18.20           O  
+ATOM   1054  N   GLU A 140       7.894  35.541  43.765  1.00 34.78           N  
+ATOM   1055  CA  GLU A 140       7.855  36.963  44.135  1.00 13.11           C  
+ATOM   1056  C   GLU A 140       9.160  37.744  43.948  1.00 15.19           C  
+ATOM   1057  O   GLU A 140       9.127  38.897  43.465  1.00 16.99           O  
+ATOM   1058  CB  GLU A 140       7.141  37.256  45.449  1.00 26.48           C  
+ATOM   1059  CG  GLU A 140       5.682  36.731  45.512  1.00  2.25           C  
+ATOM   1060  CD  GLU A 140       4.898  37.591  46.420  1.00 26.96           C  
+ATOM   1061  OE1 GLU A 140       5.385  38.556  46.896  1.00 18.81           O  
+ATOM   1062  OE2 GLU A 140       3.638  37.200  46.617  1.00 37.76           O  
+ATOM   1063  N   PRO A 141      10.311  37.097  44.279  1.00 32.41           N  
+ATOM   1064  CA  PRO A 141      11.617  37.703  44.091  1.00 24.80           C  
+ATOM   1065  C   PRO A 141      11.951  37.820  42.666  1.00 25.16           C  
+ATOM   1066  O   PRO A 141      12.221  38.943  42.153  1.00 40.44           O  
+ATOM   1067  CB  PRO A 141      12.628  36.802  44.804  1.00 36.17           C  
+ATOM   1068  CG  PRO A 141      11.828  35.927  45.775  1.00 27.20           C  
+ATOM   1069  CD  PRO A 141      10.359  36.059  45.361  1.00 41.52           C  
+ATOM   1070  N   HIS A 142      11.898  36.659  41.994  1.00 29.39           N  
+ATOM   1071  CA  HIS A 142      12.098  36.576  40.556  1.00 21.92           C  
+ATOM   1072  C   HIS A 142      11.354  37.767  39.864  1.00 11.32           C  
+ATOM   1073  O   HIS A 142      11.977  38.756  39.505  1.00 31.93           O  
+ATOM   1074  CB  HIS A 142      11.635  35.201  40.053  1.00 28.40           C  
+ATOM   1075  CG  HIS A 142      12.364  34.730  38.823  1.00 37.16           C  
+ATOM   1076  ND1 HIS A 142      12.032  33.518  38.173  1.00 29.64           N  
+ATOM   1077  CD2 HIS A 142      13.369  35.318  38.132  1.00 17.78           C  
+ATOM   1078  CE1 HIS A 142      12.849  33.418  37.158  1.00 33.43           C  
+ATOM   1079  NE2 HIS A 142      13.664  34.483  37.106  1.00 33.94           N  
+ATOM   1080  N   ALA A 143      10.003  37.728  39.866  1.00  9.23           N  
+ATOM   1081  CA  ALA A 143       9.209  38.852  39.402  1.00 12.43           C  
+ATOM   1082  C   ALA A 143       9.821  40.203  39.811  1.00 12.20           C  
+ATOM   1083  O   ALA A 143       9.987  41.083  38.985  1.00 40.12           O  
+ATOM   1084  CB  ALA A 143       7.787  38.746  39.897  1.00 17.38           C  
+ATOM   1085  N   ARG A 144      10.168  40.350  41.095  1.00 22.73           N  
+ATOM   1086  CA  ARG A 144      10.788  41.591  41.607  1.00 14.78           C  
+ATOM   1087  C   ARG A 144      11.993  41.920  40.813  1.00 20.92           C  
+ATOM   1088  O   ARG A 144      12.092  42.991  40.268  1.00 49.02           O  
+ATOM   1089  CB  ARG A 144      11.162  41.484  43.102  1.00 42.99           C  
+ATOM   1090  CG  ARG A 144      11.489  42.841  43.794  1.00 42.97           C  
+ATOM   1091  CD  ARG A 144      11.711  42.734  45.347  1.00 13.75           C  
+ATOM   1092  NE  ARG A 144      10.577  42.142  46.019  1.00 32.56           N  
+ATOM   1093  CZ  ARG A 144      10.581  40.991  46.689  1.00  1.00           C  
+ATOM   1094  NH1 ARG A 144      11.678  40.308  46.901  1.00  6.25           N  
+ATOM   1095  NH2 ARG A 144       9.409  40.503  47.167  1.00 25.13           N  
+ATOM   1096  N   PHE A 145      12.935  40.970  40.730  1.00 10.03           N  
+ATOM   1097  CA  PHE A 145      14.166  41.186  39.899  1.00  7.02           C  
+ATOM   1098  C   PHE A 145      13.859  41.960  38.631  1.00 26.95           C  
+ATOM   1099  O   PHE A 145      14.508  42.948  38.357  1.00 47.64           O  
+ATOM   1100  CB  PHE A 145      14.862  39.849  39.534  1.00 14.88           C  
+ATOM   1101  CG  PHE A 145      16.196  40.037  38.790  1.00 24.59           C  
+ATOM   1102  CD1 PHE A 145      17.264  40.715  39.380  1.00 25.34           C  
+ATOM   1103  CD2 PHE A 145      16.392  39.487  37.528  1.00 34.12           C  
+ATOM   1104  CE1 PHE A 145      18.488  40.874  38.733  1.00 25.07           C  
+ATOM   1105  CE2 PHE A 145      17.601  39.634  36.857  1.00 45.96           C  
+ATOM   1106  CZ  PHE A 145      18.649  40.333  37.461  1.00 54.97           C  
+ATOM   1107  N   TYR A 146      12.809  41.478  37.849  1.00 36.25           N  
+ATOM   1108  CA  TYR A 146      12.338  42.108  36.563  1.00 24.55           C  
+ATOM   1109  C   TYR A 146      11.756  43.484  36.771  1.00 29.37           C  
+ATOM   1110  O   TYR A 146      12.310  44.514  36.315  1.00 31.23           O  
+ATOM   1111  CB  TYR A 146      11.327  41.224  35.812  1.00 30.31           C  
+ATOM   1112  CG  TYR A 146      11.886  39.850  35.516  1.00 12.03           C  
+ATOM   1113  CD1 TYR A 146      13.259  39.669  35.371  1.00  9.90           C  
+ATOM   1114  CD2 TYR A 146      11.058  38.741  35.367  1.00  5.61           C  
+ATOM   1115  CE1 TYR A 146      13.805  38.423  35.064  1.00  5.79           C  
+ATOM   1116  CE2 TYR A 146      11.603  37.458  35.206  1.00  6.69           C  
+ATOM   1117  CZ  TYR A 146      12.980  37.304  35.027  1.00 26.40           C  
+ATOM   1118  OH  TYR A 146      13.524  36.041  34.788  1.00 33.25           O  
+ATOM   1119  N   ALA A 147      10.652  43.513  37.484  1.00 25.22           N  
+ATOM   1120  CA  ALA A 147      10.007  44.776  37.844  1.00 19.10           C  
+ATOM   1121  C   ALA A 147      11.038  45.870  38.172  1.00 23.94           C  
+ATOM   1122  O   ALA A 147      10.990  46.961  37.642  1.00 42.49           O  
+ATOM   1123  CB  ALA A 147       9.054  44.579  39.001  1.00 24.55           C  
+ATOM   1124  N   ALA A 148      11.985  45.559  39.051  1.00 15.63           N  
+ATOM   1125  CA  ALA A 148      12.999  46.519  39.383  1.00 16.53           C  
+ATOM   1126  C   ALA A 148      13.648  47.061  38.140  1.00 18.01           C  
+ATOM   1127  O   ALA A 148      14.239  48.127  38.168  1.00 37.90           O  
+ATOM   1128  CB  ALA A 148      14.047  45.912  40.293  1.00 24.60           C  
+ATOM   1129  N   GLN A 149      13.578  46.271  37.032  1.00 17.25           N  
+ATOM   1130  CA  GLN A 149      14.200  46.663  35.777  1.00  7.33           C  
+ATOM   1131  C   GLN A 149      13.274  47.546  34.899  1.00 33.26           C  
+ATOM   1132  O   GLN A 149      13.705  48.550  34.280  1.00 12.79           O  
+ATOM   1133  CB  GLN A 149      14.899  45.491  35.073  1.00 16.26           C  
+ATOM   1134  CG  GLN A 149      15.822  44.687  36.071  1.00 14.17           C  
+ATOM   1135  CD  GLN A 149      16.203  43.298  35.575  1.00 49.97           C  
+ATOM   1136  OE1 GLN A 149      16.991  43.153  34.641  1.00 13.92           O  
+ATOM   1137  NE2 GLN A 149      15.616  42.267  36.194  1.00 56.01           N  
+ATOM   1138  N   ILE A 150      11.974  47.276  34.972  1.00 25.83           N  
+ATOM   1139  CA  ILE A 150      11.013  48.126  34.289  1.00  8.70           C  
+ATOM   1140  C   ILE A 150      10.965  49.518  34.924  1.00 20.08           C  
+ATOM   1141  O   ILE A 150      11.015  50.539  34.237  1.00 36.20           O  
+ATOM   1142  CB  ILE A 150       9.603  47.518  34.265  1.00 28.41           C  
+ATOM   1143  CG1 ILE A 150       9.463  46.429  33.156  1.00 43.16           C  
+ATOM   1144  CG2 ILE A 150       8.578  48.623  34.022  1.00 26.99           C  
+ATOM   1145  CD1 ILE A 150       9.991  45.052  33.549  1.00 27.55           C  
+ATOM   1146  N   VAL A 151      10.839  49.526  36.271  1.00 17.52           N  
+ATOM   1147  CA  VAL A 151      10.764  50.735  37.056  1.00 10.80           C  
+ATOM   1148  C   VAL A 151      11.920  51.648  36.718  1.00 21.58           C  
+ATOM   1149  O   VAL A 151      11.733  52.684  36.106  1.00 43.50           O  
+ATOM   1150  CB  VAL A 151      10.522  50.446  38.594  1.00 20.63           C  
+ATOM   1151  CG1 VAL A 151      10.427  51.713  39.402  1.00 15.54           C  
+ATOM   1152  CG2 VAL A 151       9.200  49.680  38.765  1.00 19.87           C  
+ATOM   1153  N   LEU A 152      13.126  51.179  36.906  1.00 24.46           N  
+ATOM   1154  CA  LEU A 152      14.254  51.964  36.459  1.00 30.48           C  
+ATOM   1155  C   LEU A 152      14.040  52.420  34.935  1.00 45.85           C  
+ATOM   1156  O   LEU A 152      14.193  53.607  34.561  1.00 21.97           O  
+ATOM   1157  CB  LEU A 152      15.575  51.158  36.642  1.00 34.66           C  
+ATOM   1158  CG  LEU A 152      16.437  51.593  37.838  1.00 46.85           C  
+ATOM   1159  CD1 LEU A 152      15.556  51.981  39.021  1.00 27.23           C  
+ATOM   1160  CD2 LEU A 152      17.394  50.459  38.239  1.00 41.14           C  
+ATOM   1161  N   THR A 153      13.613  51.458  34.083  1.00 35.85           N  
+ATOM   1162  CA  THR A 153      13.413  51.739  32.674  1.00 32.98           C  
+ATOM   1163  C   THR A 153      12.410  52.860  32.417  1.00 36.84           C  
+ATOM   1164  O   THR A 153      12.725  53.836  31.773  1.00 43.32           O  
+ATOM   1165  CB  THR A 153      13.135  50.483  31.805  1.00 37.98           C  
+ATOM   1166  OG1 THR A 153      14.173  49.514  31.959  1.00 26.12           O  
+ATOM   1167  CG2 THR A 153      13.066  50.901  30.359  1.00 28.57           C  
+ATOM   1168  N   PHE A 154      11.214  52.713  32.938  1.00 19.26           N  
+ATOM   1169  CA  PHE A 154      10.173  53.734  32.794  1.00 14.96           C  
+ATOM   1170  C   PHE A 154      10.551  55.047  33.512  1.00 53.21           C  
+ATOM   1171  O   PHE A 154      10.077  56.130  33.166  1.00 53.90           O  
+ATOM   1172  CB  PHE A 154       8.841  53.234  33.292  1.00 23.67           C  
+ATOM   1173  CG  PHE A 154       8.316  52.096  32.482  1.00 34.64           C  
+ATOM   1174  CD1 PHE A 154       9.152  51.372  31.640  1.00 36.84           C  
+ATOM   1175  CD2 PHE A 154       6.987  51.702  32.597  1.00 39.98           C  
+ATOM   1176  CE1 PHE A 154       8.672  50.290  30.913  1.00 32.25           C  
+ATOM   1177  CE2 PHE A 154       6.479  50.640  31.857  1.00 35.69           C  
+ATOM   1178  CZ  PHE A 154       7.333  49.932  31.019  1.00 24.65           C  
+ATOM   1179  N   GLU A 155      11.378  54.937  34.536  1.00 35.11           N  
+ATOM   1180  CA  GLU A 155      11.861  56.106  35.212  1.00 33.28           C  
+ATOM   1181  C   GLU A 155      12.621  56.880  34.203  1.00 33.31           C  
+ATOM   1182  O   GLU A 155      12.288  58.015  33.877  1.00 42.76           O  
+ATOM   1183  CB  GLU A 155      12.805  55.713  36.415  1.00 44.22           C  
+ATOM   1184  CG  GLU A 155      13.672  56.881  36.999  1.00 49.32           C  
+ATOM   1185  CD  GLU A 155      14.640  56.430  38.089  1.00 82.41           C  
+ATOM   1186  OE1 GLU A 155      14.280  56.109  39.208  1.00 73.30           O  
+ATOM   1187  OE2 GLU A 155      15.903  56.353  37.671  1.00 32.47           O  
+ATOM   1188  N   TYR A 156      13.632  56.185  33.642  1.00 24.80           N  
+ATOM   1189  CA  TYR A 156      14.474  56.703  32.592  1.00 23.16           C  
+ATOM   1190  C   TYR A 156      13.661  57.299  31.432  1.00 47.94           C  
+ATOM   1191  O   TYR A 156      13.806  58.456  31.104  1.00 70.76           O  
+ATOM   1192  CB  TYR A 156      15.400  55.616  32.067  1.00 13.50           C  
+ATOM   1193  CG  TYR A 156      16.103  56.020  30.811  1.00 19.87           C  
+ATOM   1194  CD1 TYR A 156      15.491  55.899  29.565  1.00 30.90           C  
+ATOM   1195  CD2 TYR A 156      17.412  56.474  30.856  1.00 18.75           C  
+ATOM   1196  CE1 TYR A 156      16.152  56.275  28.401  1.00 22.06           C  
+ATOM   1197  CE2 TYR A 156      18.091  56.871  29.705  1.00  9.93           C  
+ATOM   1198  CZ  TYR A 156      17.458  56.765  28.479  1.00 33.40           C  
+ATOM   1199  OH  TYR A 156      18.129  57.127  27.353  1.00 57.20           O  
+ATOM   1200  N   LEU A 157      12.851  56.459  30.772  1.00 32.45           N  
+ATOM   1201  CA  LEU A 157      12.035  56.910  29.647  1.00 29.87           C  
+ATOM   1202  C   LEU A 157      11.248  58.110  30.027  1.00 14.74           C  
+ATOM   1203  O   LEU A 157      11.537  59.201  29.593  1.00 48.01           O  
+ATOM   1204  CB  LEU A 157      10.990  55.847  29.158  1.00 35.19           C  
+ATOM   1205  CG  LEU A 157      11.489  54.681  28.311  1.00 16.63           C  
+ATOM   1206  CD1 LEU A 157      10.265  53.909  27.815  1.00 13.32           C  
+ATOM   1207  CD2 LEU A 157      12.321  55.171  27.125  1.00  8.28           C  
+ATOM   1208  N   HIS A 158      10.153  57.843  30.784  1.00 35.06           N  
+ATOM   1209  CA  HIS A 158       9.157  58.839  31.234  1.00 25.95           C  
+ATOM   1210  C   HIS A 158       9.766  60.244  31.400  1.00 18.15           C  
+ATOM   1211  O   HIS A 158       9.162  61.264  31.043  1.00 20.52           O  
+ATOM   1212  CB  HIS A 158       8.379  58.329  32.512  1.00 28.95           C  
+ATOM   1213  CG  HIS A 158       7.447  57.138  32.222  1.00 34.63           C  
+ATOM   1214  ND1 HIS A 158       6.062  57.205  32.443  1.00 40.07           N  
+ATOM   1215  CD2 HIS A 158       7.705  55.914  31.697  1.00 35.96           C  
+ATOM   1216  CE1 HIS A 158       5.525  56.050  32.045  1.00 21.39           C  
+ATOM   1217  NE2 HIS A 158       6.473  55.258  31.580  1.00 30.12           N  
+ATOM   1218  N   SER A 159      11.026  60.271  31.838  1.00 19.32           N  
+ATOM   1219  CA  SER A 159      11.797  61.524  32.042  1.00  9.53           C  
+ATOM   1220  C   SER A 159      12.105  62.268  30.763  1.00 15.25           C  
+ATOM   1221  O   SER A 159      12.645  63.371  30.811  1.00 44.65           O  
+ATOM   1222  CB  SER A 159      13.120  61.241  32.793  1.00 53.33           C  
+ATOM   1223  OG  SER A 159      14.230  61.190  31.880  1.00 35.05           O  
+ATOM   1224  N   LEU A 160      11.881  61.578  29.591  1.00 45.78           N  
+ATOM   1225  CA  LEU A 160      12.188  62.103  28.238  1.00 29.34           C  
+ATOM   1226  C   LEU A 160      10.981  62.312  27.456  1.00 33.84           C  
+ATOM   1227  O   LEU A 160      11.006  62.303  26.220  1.00 35.70           O  
+ATOM   1228  CB  LEU A 160      13.115  61.176  27.442  1.00 30.77           C  
+ATOM   1229  CG  LEU A 160      14.552  61.253  27.880  1.00 23.16           C  
+ATOM   1230  CD1 LEU A 160      14.655  61.956  29.227  1.00 37.59           C  
+ATOM   1231  CD2 LEU A 160      15.103  59.854  27.996  1.00 16.27           C  
+ATOM   1232  N   ASP A 161       9.911  62.416  28.140  1.00 33.10           N  
+ATOM   1233  CA  ASP A 161       8.689  62.676  27.490  1.00 29.00           C  
+ATOM   1234  C   ASP A 161       8.365  61.602  26.503  1.00 14.82           C  
+ATOM   1235  O   ASP A 161       7.787  61.858  25.478  1.00 50.00           O  
+ATOM   1236  CB  ASP A 161       8.710  64.070  26.854  1.00 26.17           C  
+ATOM   1237  CG  ASP A 161       9.222  65.162  27.830  1.00 77.11           C  
+ATOM   1238  OD1 ASP A 161       8.546  65.587  28.767  1.00 25.98           O  
+ATOM   1239  OD2 ASP A 161      10.491  65.565  27.593  1.00 42.84           O  
+ATOM   1240  N   LEU A 162       8.630  60.368  26.915  1.00 16.61           N  
+ATOM   1241  CA  LEU A 162       8.321  59.206  26.127  1.00 17.51           C  
+ATOM   1242  C   LEU A 162       7.431  58.221  26.814  1.00 22.08           C  
+ATOM   1243  O   LEU A 162       7.928  57.393  27.504  1.00 38.81           O  
+ATOM   1244  CB  LEU A 162       9.582  58.457  25.856  1.00 22.79           C  
+ATOM   1245  CG  LEU A 162      10.483  59.176  24.931  1.00 41.37           C  
+ATOM   1246  CD1 LEU A 162      11.908  58.557  24.985  1.00 10.17           C  
+ATOM   1247  CD2 LEU A 162       9.888  59.075  23.537  1.00 22.50           C  
+ATOM   1248  N   ILE A 163       6.129  58.219  26.522  1.00 13.18           N  
+ATOM   1249  CA  ILE A 163       5.262  57.128  26.972  1.00  1.27           C  
+ATOM   1250  C   ILE A 163       5.798  55.917  26.263  1.00 23.53           C  
+ATOM   1251  O   ILE A 163       6.399  56.097  25.249  1.00 38.77           O  
+ATOM   1252  CB  ILE A 163       3.825  57.345  26.484  1.00  3.97           C  
+ATOM   1253  CG1 ILE A 163       3.246  58.646  27.046  1.00 14.44           C  
+ATOM   1254  CG2 ILE A 163       2.945  56.169  26.877  1.00 30.20           C  
+ATOM   1255  CD1 ILE A 163       1.877  59.003  26.427  1.00 32.15           C  
+ATOM   1256  N   TYR A 164       5.599  54.677  26.794  1.00 34.44           N  
+ATOM   1257  CA  TYR A 164       6.102  53.452  26.106  1.00 11.81           C  
+ATOM   1258  C   TYR A 164       4.999  52.725  25.300  1.00  9.74           C  
+ATOM   1259  O   TYR A 164       5.222  52.246  24.216  1.00 38.63           O  
+ATOM   1260  CB  TYR A 164       6.876  52.550  27.030  1.00 31.73           C  
+ATOM   1261  CG  TYR A 164       7.206  51.212  26.433  1.00 34.52           C  
+ATOM   1262  CD1 TYR A 164       8.326  51.034  25.618  1.00 32.37           C  
+ATOM   1263  CD2 TYR A 164       6.426  50.093  26.738  1.00 37.37           C  
+ATOM   1264  CE1 TYR A 164       8.639  49.779  25.084  1.00 16.90           C  
+ATOM   1265  CE2 TYR A 164       6.717  48.829  26.209  1.00 11.47           C  
+ATOM   1266  CZ  TYR A 164       7.810  48.686  25.346  1.00 19.73           C  
+ATOM   1267  OH  TYR A 164       8.107  47.452  24.790  1.00 29.71           O  
+ATOM   1268  N   ARG A 165       3.807  52.706  25.868  1.00 15.20           N  
+ATOM   1269  CA  ARG A 165       2.536  52.264  25.258  1.00  1.18           C  
+ATOM   1270  C   ARG A 165       2.321  50.778  24.944  1.00 17.78           C  
+ATOM   1271  O   ARG A 165       1.191  50.329  24.672  1.00 23.02           O  
+ATOM   1272  CB  ARG A 165       2.138  53.150  24.131  1.00 46.71           C  
+ATOM   1273  CG  ARG A 165       1.764  54.541  24.590  1.00 21.75           C  
+ATOM   1274  CD  ARG A 165       2.271  55.638  23.653  1.00 59.40           C  
+ATOM   1275  NE  ARG A 165       2.195  55.282  22.220  1.00 62.67           N  
+ATOM   1276  CZ  ARG A 165       1.216  55.661  21.360  1.00 44.85           C  
+ATOM   1277  NH1 ARG A 165       0.177  56.397  21.726  1.00 18.57           N  
+ATOM   1278  NH2 ARG A 165       1.293  55.280  20.095  1.00 70.94           N  
+ATOM   1279  N   ASP A 166       3.311  50.017  25.058  1.00 14.43           N  
+ATOM   1280  CA  ASP A 166       3.161  48.645  24.708  1.00  8.77           C  
+ATOM   1281  C   ASP A 166       4.017  47.682  25.564  1.00 61.22           C  
+ATOM   1282  O   ASP A 166       4.933  47.028  25.048  1.00 54.63           O  
+ATOM   1283  CB  ASP A 166       3.553  48.514  23.247  1.00 32.45           C  
+ATOM   1284  CG  ASP A 166       3.158  47.229  22.628  1.00 62.47           C  
+ATOM   1285  OD1 ASP A 166       2.169  46.597  22.968  1.00 56.69           O  
+ATOM   1286  OD2 ASP A 166       3.964  46.875  21.645  1.00 32.16           O  
+ATOM   1287  N   LEU A 167       3.682  47.554  26.877  1.00 83.67           N  
+ATOM   1288  CA  LEU A 167       4.420  46.626  27.769  1.00 60.69           C  
+ATOM   1289  C   LEU A 167       3.825  45.218  27.874  1.00 33.35           C  
+ATOM   1290  O   LEU A 167       2.657  45.026  28.237  1.00 17.86           O  
+ATOM   1291  CB  LEU A 167       4.681  47.159  29.146  1.00 43.60           C  
+ATOM   1292  CG  LEU A 167       5.710  46.305  29.771  1.00 25.46           C  
+ATOM   1293  CD1 LEU A 167       6.697  45.901  28.656  1.00 14.97           C  
+ATOM   1294  CD2 LEU A 167       6.425  47.064  30.835  1.00 15.65           C  
+ATOM   1295  N   LYS A 168       4.666  44.232  27.663  1.00 17.60           N  
+ATOM   1296  CA  LYS A 168       4.200  42.888  27.746  1.00  5.68           C  
+ATOM   1297  C   LYS A 168       5.345  41.849  27.695  1.00 25.38           C  
+ATOM   1298  O   LYS A 168       6.502  42.188  27.506  1.00 33.73           O  
+ATOM   1299  CB  LYS A 168       3.088  42.660  26.779  1.00  1.00           C  
+ATOM   1300  CG  LYS A 168       3.449  43.120  25.403  1.00 35.92           C  
+ATOM   1301  CD  LYS A 168       2.631  42.402  24.334  1.00 33.26           C  
+ATOM   1302  CE  LYS A 168       3.336  42.311  23.013  1.00 12.56           C  
+ATOM   1303  NZ  LYS A 168       2.404  42.190  21.879  1.00 51.67           N  
+ATOM   1304  N   PRO A 169       5.030  40.608  27.986  1.00 13.80           N  
+ATOM   1305  CA  PRO A 169       6.060  39.604  28.158  1.00 10.25           C  
+ATOM   1306  C   PRO A 169       6.762  39.245  26.913  1.00 23.97           C  
+ATOM   1307  O   PRO A 169       7.938  38.833  26.935  1.00 28.42           O  
+ATOM   1308  CB  PRO A 169       5.411  38.383  28.824  1.00 14.24           C  
+ATOM   1309  CG  PRO A 169       3.979  38.787  29.167  1.00 12.43           C  
+ATOM   1310  CD  PRO A 169       3.708  40.112  28.415  1.00  6.19           C  
+ATOM   1311  N   GLU A 170       6.072  39.438  25.806  1.00 23.54           N  
+ATOM   1312  CA  GLU A 170       6.661  39.196  24.504  1.00 19.56           C  
+ATOM   1313  C   GLU A 170       7.734  40.271  24.117  1.00 20.30           C  
+ATOM   1314  O   GLU A 170       8.598  40.049  23.250  1.00 18.76           O  
+ATOM   1315  CB  GLU A 170       5.613  39.063  23.464  1.00 18.29           C  
+ATOM   1316  CG  GLU A 170       4.566  38.009  23.799  1.00 10.94           C  
+ATOM   1317  CD  GLU A 170       3.462  38.585  24.563  1.00 20.84           C  
+ATOM   1318  OE1 GLU A 170       3.615  39.490  25.334  1.00 81.05           O  
+ATOM   1319  OE2 GLU A 170       2.304  38.074  24.248  1.00 48.13           O  
+ATOM   1320  N   ASN A 171       7.703  41.408  24.809  1.00 21.40           N  
+ATOM   1321  CA  ASN A 171       8.663  42.456  24.567  1.00  3.39           C  
+ATOM   1322  C   ASN A 171       9.727  42.444  25.535  1.00 19.26           C  
+ATOM   1323  O   ASN A 171      10.611  43.258  25.480  1.00 28.42           O  
+ATOM   1324  CB  ASN A 171       8.037  43.789  24.544  1.00  7.88           C  
+ATOM   1325  CG  ASN A 171       6.896  43.798  23.594  1.00 47.46           C  
+ATOM   1326  OD1 ASN A 171       6.276  42.772  23.350  1.00 27.38           O  
+ATOM   1327  ND2 ASN A 171       6.692  44.914  22.973  1.00 13.35           N  
+ATOM   1328  N   LEU A 172       9.653  41.538  26.461  1.00 11.74           N  
+ATOM   1329  CA  LEU A 172      10.663  41.502  27.446  1.00  6.45           C  
+ATOM   1330  C   LEU A 172      11.583  40.379  27.187  1.00  1.18           C  
+ATOM   1331  O   LEU A 172      11.301  39.222  27.527  1.00  9.16           O  
+ATOM   1332  CB  LEU A 172      10.062  41.427  28.857  1.00 33.02           C  
+ATOM   1333  CG  LEU A 172       9.435  42.740  29.374  1.00 23.16           C  
+ATOM   1334  CD1 LEU A 172      10.488  43.593  30.081  1.00 28.95           C  
+ATOM   1335  CD2 LEU A 172       8.844  43.522  28.248  1.00 11.48           C  
+ATOM   1336  N   LEU A 173      12.653  40.675  26.546  1.00  9.58           N  
+ATOM   1337  CA  LEU A 173      13.620  39.633  26.206  1.00 25.64           C  
+ATOM   1338  C   LEU A 173      14.564  39.387  27.328  1.00  4.79           C  
+ATOM   1339  O   LEU A 173      14.838  40.301  28.105  1.00 51.00           O  
+ATOM   1340  CB  LEU A 173      14.416  39.989  24.908  1.00 36.89           C  
+ATOM   1341  CG  LEU A 173      13.536  40.357  23.725  1.00 25.09           C  
+ATOM   1342  CD1 LEU A 173      14.287  41.271  22.792  1.00 17.75           C  
+ATOM   1343  CD2 LEU A 173      13.144  39.097  22.977  1.00 20.26           C  
+ATOM   1344  N   ILE A 174      15.157  38.173  27.363  1.00 45.32           N  
+ATOM   1345  CA  ILE A 174      16.134  37.788  28.423  1.00 41.05           C  
+ATOM   1346  C   ILE A 174      17.514  37.529  27.896  1.00 53.96           C  
+ATOM   1347  O   ILE A 174      17.718  36.659  27.052  1.00 93.81           O  
+ATOM   1348  CB  ILE A 174      15.672  36.574  29.235  1.00 40.22           C  
+ATOM   1349  CG1 ILE A 174      14.450  36.950  30.081  1.00 33.71           C  
+ATOM   1350  CG2 ILE A 174      16.828  36.095  30.138  1.00 28.22           C  
+ATOM   1351  CD1 ILE A 174      13.246  36.053  29.835  1.00 35.83           C  
+ATOM   1352  N   ASP A 175      18.477  38.244  28.450  1.00 31.77           N  
+ATOM   1353  CA  ASP A 175      19.871  38.087  28.073  1.00 11.43           C  
+ATOM   1354  C   ASP A 175      20.663  36.958  28.866  1.00 17.63           C  
+ATOM   1355  O   ASP A 175      20.145  36.290  29.783  1.00 51.81           O  
+ATOM   1356  CB  ASP A 175      20.610  39.430  27.985  1.00 35.87           C  
+ATOM   1357  CG  ASP A 175      21.084  39.997  29.276  1.00 25.83           C  
+ATOM   1358  OD1 ASP A 175      21.536  39.315  30.177  1.00 45.95           O  
+ATOM   1359  OD2 ASP A 175      21.130  41.288  29.231  1.00 47.95           O  
+ATOM   1360  N   GLN A 176      21.902  36.726  28.451  1.00 12.50           N  
+ATOM   1361  CA  GLN A 176      22.739  35.662  29.016  1.00 35.79           C  
+ATOM   1362  C   GLN A 176      22.959  35.813  30.494  1.00 51.44           C  
+ATOM   1363  O   GLN A 176      23.630  34.963  31.150  1.00 26.04           O  
+ATOM   1364  CB  GLN A 176      24.096  35.534  28.278  1.00 49.85           C  
+ATOM   1365  CG  GLN A 176      24.660  36.887  27.776  1.00100.00           C  
+ATOM   1366  CD  GLN A 176      24.351  37.152  26.302  1.00100.00           C  
+ATOM   1367  OE1 GLN A 176      23.699  38.169  25.953  1.00 99.96           O  
+ATOM   1368  NE2 GLN A 176      24.834  36.241  25.427  1.00100.00           N  
+ATOM   1369  N   GLN A 177      22.424  36.895  31.023  1.00 28.13           N  
+ATOM   1370  CA  GLN A 177      22.557  37.169  32.409  1.00 34.50           C  
+ATOM   1371  C   GLN A 177      21.246  37.576  33.031  1.00 54.32           C  
+ATOM   1372  O   GLN A 177      21.191  38.467  33.859  1.00 68.78           O  
+ATOM   1373  CB  GLN A 177      23.691  38.129  32.688  1.00 22.72           C  
+ATOM   1374  CG  GLN A 177      24.027  38.959  31.442  1.00 38.88           C  
+ATOM   1375  CD  GLN A 177      25.488  38.912  31.084  1.00 62.13           C  
+ATOM   1376  OE1 GLN A 177      26.084  39.931  30.747  1.00 75.81           O  
+ATOM   1377  NE2 GLN A 177      26.063  37.705  31.091  1.00 38.41           N  
+ATOM   1378  N   GLY A 178      20.174  36.898  32.565  1.00 31.04           N  
+ATOM   1379  CA  GLY A 178      18.816  37.017  33.084  1.00  9.85           C  
+ATOM   1380  C   GLY A 178      18.282  38.418  33.208  1.00 31.04           C  
+ATOM   1381  O   GLY A 178      17.141  38.604  33.623  1.00 63.03           O  
+ATOM   1382  N   TYR A 179      19.089  39.417  32.892  1.00 23.43           N  
+ATOM   1383  CA  TYR A 179      18.600  40.793  32.948  1.00 25.82           C  
+ATOM   1384  C   TYR A 179      17.726  41.084  31.756  1.00 14.93           C  
+ATOM   1385  O   TYR A 179      17.614  40.287  30.895  1.00  8.12           O  
+ATOM   1386  CB  TYR A 179      19.706  41.790  33.054  1.00 36.60           C  
+ATOM   1387  CG  TYR A 179      20.178  41.989  34.453  1.00 45.06           C  
+ATOM   1388  CD1 TYR A 179      21.175  41.175  34.992  1.00 51.66           C  
+ATOM   1389  CD2 TYR A 179      19.701  43.050  35.217  1.00 50.13           C  
+ATOM   1390  CE1 TYR A 179      21.658  41.381  36.282  1.00 41.90           C  
+ATOM   1391  CE2 TYR A 179      20.176  43.275  36.507  1.00 63.21           C  
+ATOM   1392  CZ  TYR A 179      21.147  42.428  37.041  1.00 12.55           C  
+ATOM   1393  OH  TYR A 179      21.639  42.660  38.288  1.00 75.52           O  
+ATOM   1394  N   ILE A 180      17.104  42.225  31.683  1.00 11.95           N  
+ATOM   1395  CA  ILE A 180      16.224  42.375  30.570  1.00 14.13           C  
+ATOM   1396  C   ILE A 180      16.422  43.539  29.638  1.00 31.51           C  
+ATOM   1397  O   ILE A 180      16.868  44.615  29.997  1.00 21.61           O  
+ATOM   1398  CB  ILE A 180      14.817  42.256  30.954  1.00 11.75           C  
+ATOM   1399  CG1 ILE A 180      14.319  43.569  31.423  1.00 18.49           C  
+ATOM   1400  CG2 ILE A 180      14.671  41.223  32.056  1.00 21.58           C  
+ATOM   1401  CD1 ILE A 180      13.010  43.429  32.203  1.00 47.33           C  
+ATOM   1402  N   GLN A 181      15.995  43.290  28.417  1.00 27.61           N  
+ATOM   1403  CA  GLN A 181      15.988  44.244  27.389  1.00 22.14           C  
+ATOM   1404  C   GLN A 181      14.686  44.202  26.737  1.00  5.99           C  
+ATOM   1405  O   GLN A 181      14.231  43.144  26.348  1.00 23.57           O  
+ATOM   1406  CB  GLN A 181      17.050  44.010  26.354  1.00 22.11           C  
+ATOM   1407  CG  GLN A 181      18.222  43.203  26.856  1.00  1.00           C  
+ATOM   1408  CD  GLN A 181      19.325  44.079  27.339  1.00 33.11           C  
+ATOM   1409  OE1 GLN A 181      20.408  44.078  26.766  1.00 45.35           O  
+ATOM   1410  NE2 GLN A 181      19.051  44.851  28.405  1.00 68.20           N  
+ATOM   1411  N   VAL A 182      14.076  45.365  26.671  1.00 17.55           N  
+ATOM   1412  CA  VAL A 182      12.792  45.590  26.073  1.00  7.43           C  
+ATOM   1413  C   VAL A 182      12.942  46.007  24.656  1.00 31.37           C  
+ATOM   1414  O   VAL A 182      13.732  46.886  24.334  1.00 26.46           O  
+ATOM   1415  CB  VAL A 182      11.988  46.667  26.855  1.00 21.24           C  
+ATOM   1416  CG1 VAL A 182      12.884  47.821  27.196  1.00 22.07           C  
+ATOM   1417  CG2 VAL A 182      10.830  47.190  26.037  1.00 19.76           C  
+ATOM   1418  N   THR A 183      12.183  45.381  23.813  1.00 38.80           N  
+ATOM   1419  CA  THR A 183      12.224  45.689  22.443  1.00 42.83           C  
+ATOM   1420  C   THR A 183      10.906  46.225  21.953  1.00 48.37           C  
+ATOM   1421  O   THR A 183       9.960  46.386  22.727  1.00 33.17           O  
+ATOM   1422  CB  THR A 183      12.776  44.512  21.564  1.00 45.63           C  
+ATOM   1423  OG1 THR A 183      12.652  44.826  20.193  1.00 70.64           O  
+ATOM   1424  CG2 THR A 183      12.058  43.196  21.866  1.00  4.39           C  
+ATOM   1425  N   ASP A 184      10.887  46.550  20.664  1.00 35.88           N  
+ATOM   1426  CA  ASP A 184       9.735  47.018  19.980  1.00 12.64           C  
+ATOM   1427  C   ASP A 184       9.138  48.327  20.474  1.00 15.81           C  
+ATOM   1428  O   ASP A 184       8.038  48.368  21.000  1.00 45.66           O  
+ATOM   1429  CB  ASP A 184       8.676  45.924  19.794  1.00 24.18           C  
+ATOM   1430  CG  ASP A 184       7.581  46.326  18.837  1.00 78.64           C  
+ATOM   1431  OD1 ASP A 184       7.568  47.393  18.235  1.00 90.63           O  
+ATOM   1432  OD2 ASP A 184       6.612  45.440  18.772  1.00 39.23           O  
+ATOM   1433  N   PHE A 185       9.794  49.404  20.145  1.00 18.02           N  
+ATOM   1434  CA  PHE A 185       9.300  50.712  20.456  1.00  6.31           C  
+ATOM   1435  C   PHE A 185       8.300  51.183  19.421  1.00 25.46           C  
+ATOM   1436  O   PHE A 185       8.080  52.359  19.230  1.00 19.36           O  
+ATOM   1437  CB  PHE A 185      10.438  51.674  20.481  1.00 10.75           C  
+ATOM   1438  CG  PHE A 185      11.232  51.472  21.648  1.00 11.31           C  
+ATOM   1439  CD1 PHE A 185      12.205  50.481  21.696  1.00 28.33           C  
+ATOM   1440  CD2 PHE A 185      10.989  52.229  22.780  1.00 24.48           C  
+ATOM   1441  CE1 PHE A 185      12.957  50.265  22.853  1.00 35.07           C  
+ATOM   1442  CE2 PHE A 185      11.716  52.022  23.945  1.00 35.25           C  
+ATOM   1443  CZ  PHE A 185      12.699  51.035  23.983  1.00 27.42           C  
+ATOM   1444  N   GLY A 186       7.741  50.278  18.737  1.00 32.79           N  
+ATOM   1445  CA  GLY A 186       6.844  50.613  17.666  1.00 33.29           C  
+ATOM   1446  C   GLY A 186       5.617  51.408  18.060  1.00 17.79           C  
+ATOM   1447  O   GLY A 186       4.938  51.921  17.205  1.00 37.36           O  
+ATOM   1448  N   PHE A 187       5.271  51.432  19.328  1.00 29.09           N  
+ATOM   1449  CA  PHE A 187       4.071  52.179  19.754  1.00 30.52           C  
+ATOM   1450  C   PHE A 187       4.439  53.456  20.495  1.00 25.31           C  
+ATOM   1451  O   PHE A 187       3.613  54.319  20.711  1.00 25.08           O  
+ATOM   1452  CB  PHE A 187       3.086  51.333  20.608  1.00 33.56           C  
+ATOM   1453  CG  PHE A 187       2.185  50.387  19.834  1.00 34.47           C  
+ATOM   1454  CD1 PHE A 187       2.135  50.393  18.439  1.00 54.36           C  
+ATOM   1455  CD2 PHE A 187       1.324  49.523  20.518  1.00 51.69           C  
+ATOM   1456  CE1 PHE A 187       1.284  49.529  17.739  1.00 47.31           C  
+ATOM   1457  CE2 PHE A 187       0.466  48.654  19.840  1.00 55.06           C  
+ATOM   1458  CZ  PHE A 187       0.441  48.669  18.444  1.00 39.70           C  
+ATOM   1459  N   ALA A 188       5.696  53.520  20.919  1.00 23.99           N  
+ATOM   1460  CA  ALA A 188       6.220  54.646  21.658  1.00 27.01           C  
+ATOM   1461  C   ALA A 188       5.738  55.988  21.087  1.00 51.63           C  
+ATOM   1462  O   ALA A 188       5.020  56.018  20.089  1.00 37.18           O  
+ATOM   1463  CB  ALA A 188       7.769  54.567  21.770  1.00 20.32           C  
+ATOM   1464  N   LYS A 189       6.109  57.101  21.776  1.00 42.42           N  
+ATOM   1465  CA  LYS A 189       5.701  58.434  21.371  1.00 27.89           C  
+ATOM   1466  C   LYS A 189       6.190  59.478  22.303  1.00 33.48           C  
+ATOM   1467  O   LYS A 189       5.670  59.627  23.386  1.00 56.79           O  
+ATOM   1468  CB  LYS A 189       4.173  58.567  21.263  1.00 17.88           C  
+ATOM   1469  CG  LYS A 189       3.720  60.025  21.119  1.00 19.08           C  
+ATOM   1470  CD  LYS A 189       2.401  60.198  20.367  1.00 12.01           C  
+ATOM   1471  CE  LYS A 189       1.898  61.632  20.398  1.00 41.60           C  
+ATOM   1472  NZ  LYS A 189       0.427  61.759  20.265  1.00100.00           N  
+ATOM   1473  N   ARG A 190       7.127  60.271  21.870  1.00 44.33           N  
+ATOM   1474  CA  ARG A 190       7.541  61.357  22.714  1.00 45.61           C  
+ATOM   1475  C   ARG A 190       6.388  62.305  22.891  1.00 40.39           C  
+ATOM   1476  O   ARG A 190       5.869  62.816  21.924  1.00 39.84           O  
+ATOM   1477  CB  ARG A 190       8.747  62.129  22.175  1.00 18.03           C  
+ATOM   1478  CG  ARG A 190       9.200  63.221  23.144  1.00 20.58           C  
+ATOM   1479  CD  ARG A 190      10.329  64.112  22.609  1.00 22.04           C  
+ATOM   1480  NE  ARG A 190      11.202  64.630  23.686  1.00 68.40           N  
+ATOM   1481  CZ  ARG A 190      11.893  65.769  23.620  1.00 80.07           C  
+ATOM   1482  NH1 ARG A 190      11.836  66.584  22.556  1.00100.00           N  
+ATOM   1483  NH2 ARG A 190      12.646  66.111  24.659  1.00 97.20           N  
+ATOM   1484  N   VAL A 191       5.978  62.546  24.110  1.00 39.31           N  
+ATOM   1485  CA  VAL A 191       4.933  63.491  24.286  1.00 38.47           C  
+ATOM   1486  C   VAL A 191       5.079  64.321  25.456  1.00 46.05           C  
+ATOM   1487  O   VAL A 191       6.004  64.177  26.250  1.00 41.74           O  
+ATOM   1488  CB  VAL A 191       3.550  62.925  24.244  1.00 46.72           C  
+ATOM   1489  CG1 VAL A 191       3.049  62.918  22.832  1.00 60.32           C  
+ATOM   1490  CG2 VAL A 191       3.534  61.537  24.825  1.00 47.37           C  
+ATOM   1491  N   LYS A 192       4.115  65.192  25.552  1.00 53.63           N  
+ATOM   1492  CA  LYS A 192       3.935  66.086  26.637  1.00 56.07           C  
+ATOM   1493  C   LYS A 192       2.459  66.229  26.937  1.00 75.85           C  
+ATOM   1494  O   LYS A 192       1.721  66.924  26.203  1.00 96.29           O  
+ATOM   1495  CB  LYS A 192       4.535  67.421  26.358  1.00 46.59           C  
+ATOM   1496  CG  LYS A 192       5.970  67.531  26.839  1.00 43.05           C  
+ATOM   1497  CD  LYS A 192       6.993  67.431  25.715  1.00 78.47           C  
+ATOM   1498  CE  LYS A 192       8.313  68.150  26.039  1.00100.00           C  
+ATOM   1499  NZ  LYS A 192       9.054  68.623  24.839  1.00 88.40           N  
+ATOM   1500  N   GLY A 193       2.011  65.512  27.985  1.00 40.60           N  
+ATOM   1501  CA  GLY A 193       0.628  65.531  28.382  1.00 29.44           C  
+ATOM   1502  C   GLY A 193      -0.203  64.401  27.841  1.00 42.01           C  
+ATOM   1503  O   GLY A 193       0.163  63.226  27.901  1.00 54.87           O  
+ATOM   1504  N   ARG A 194      -1.392  64.755  27.366  1.00 16.74           N  
+ATOM   1505  CA  ARG A 194      -2.324  63.828  26.810  1.00 10.32           C  
+ATOM   1506  C   ARG A 194      -2.066  63.479  25.389  1.00 41.60           C  
+ATOM   1507  O   ARG A 194      -1.746  64.343  24.591  1.00 73.52           O  
+ATOM   1508  CB  ARG A 194      -3.731  64.381  26.879  1.00 19.02           C  
+ATOM   1509  CG  ARG A 194      -4.367  64.471  28.295  1.00 26.88           C  
+ATOM   1510  CD  ARG A 194      -5.630  65.301  28.245  1.00100.00           C  
+ATOM   1511  NE  ARG A 194      -6.899  64.525  27.985  1.00 49.45           N  
+ATOM   1512  CZ  ARG A 194      -7.954  65.029  27.306  1.00100.00           C  
+ATOM   1513  NH1 ARG A 194      -7.975  66.293  26.848  1.00100.00           N  
+ATOM   1514  NH2 ARG A 194      -9.047  64.249  27.187  1.00 76.96           N  
+ATOM   1515  N   THR A 195      -2.385  62.217  25.045  1.00 42.30           N  
+ATOM   1516  CA  THR A 195      -2.384  61.676  23.692  1.00 26.78           C  
+ATOM   1517  C   THR A 195      -3.640  60.840  23.642  1.00 22.77           C  
+ATOM   1518  O   THR A 195      -4.209  60.575  24.682  1.00 40.17           O  
+ATOM   1519  CB  THR A 195      -1.164  60.845  23.281  1.00  2.12           C  
+ATOM   1520  OG1 THR A 195      -1.513  59.509  23.232  1.00 67.70           O  
+ATOM   1521  CG2 THR A 195      -0.009  61.061  24.280  1.00 29.30           C  
+ATOM   1522  N   TRP A 196      -4.131  60.478  22.471  1.00 10.54           N  
+ATOM   1523  CA  TRP A 196      -5.432  59.730  22.455  1.00 24.63           C  
+ATOM   1524  C   TRP A 196      -5.477  58.417  21.647  1.00 27.67           C  
+ATOM   1525  O   TRP A 196      -6.557  57.897  21.387  1.00 33.22           O  
+ATOM   1526  CB  TRP A 196      -6.627  60.645  22.001  1.00 16.68           C  
+ATOM   1527  CG  TRP A 196      -6.903  61.831  22.891  1.00 20.11           C  
+ATOM   1528  CD1 TRP A 196      -8.091  62.083  23.584  1.00 28.40           C  
+ATOM   1529  CD2 TRP A 196      -6.076  62.982  23.083  1.00  8.26           C  
+ATOM   1530  NE1 TRP A 196      -8.028  63.295  24.235  1.00 23.06           N  
+ATOM   1531  CE2 TRP A 196      -6.807  63.889  23.934  1.00 20.99           C  
+ATOM   1532  CE3 TRP A 196      -4.812  63.329  22.653  1.00 12.94           C  
+ATOM   1533  CZ2 TRP A 196      -6.232  65.078  24.396  1.00 28.34           C  
+ATOM   1534  CZ3 TRP A 196      -4.250  64.542  23.075  1.00 28.76           C  
+ATOM   1535  CH2 TRP A 196      -4.939  65.395  23.951  1.00 30.79           C  
+HETATM 1536  N   TPO A 197      -4.341  57.895  21.243  1.00 24.54           N  
+HETATM 1537  CA  TPO A 197      -4.295  56.667  20.396  1.00 33.77           C  
+HETATM 1538  CB  TPO A 197      -2.944  56.584  19.701  1.00 80.43           C  
+HETATM 1539  CG2 TPO A 197      -2.843  55.383  18.776  1.00 53.62           C  
+HETATM 1540  OG1 TPO A 197      -2.654  57.786  19.027  1.00 28.14           O  
+HETATM 1541  P   TPO A 197      -1.200  58.363  19.216  1.00 38.66           P  
+HETATM 1542  O1P TPO A 197      -0.226  57.424  18.617  1.00 49.19           O  
+HETATM 1543  O2P TPO A 197      -1.128  59.688  18.612  1.00 65.09           O  
+HETATM 1544  O3P TPO A 197      -0.931  58.453  20.646  1.00100.00           O  
+HETATM 1545  C   TPO A 197      -4.587  55.316  21.128  1.00 37.85           C  
+HETATM 1546  O   TPO A 197      -3.898  54.922  22.052  1.00 36.15           O  
+ATOM   1547  N   LEU A 198      -5.525  54.562  20.620  1.00 23.84           N  
+ATOM   1548  CA  LEU A 198      -5.792  53.269  21.204  1.00 13.45           C  
+ATOM   1549  C   LEU A 198      -4.853  52.270  20.705  1.00 32.67           C  
+ATOM   1550  O   LEU A 198      -5.195  51.525  19.794  1.00 55.96           O  
+ATOM   1551  CB  LEU A 198      -7.207  52.781  20.885  1.00 22.99           C  
+ATOM   1552  CG  LEU A 198      -7.774  51.821  21.952  1.00 36.35           C  
+ATOM   1553  CD1 LEU A 198      -8.722  50.809  21.327  1.00 26.78           C  
+ATOM   1554  CD2 LEU A 198      -6.665  51.104  22.702  1.00 26.12           C  
+ATOM   1555  N   CYS A 199      -3.715  52.133  21.358  1.00 44.12           N  
+ATOM   1556  CA  CYS A 199      -2.780  51.067  20.949  1.00 50.11           C  
+ATOM   1557  C   CYS A 199      -2.365  50.120  22.070  1.00 57.39           C  
+ATOM   1558  O   CYS A 199      -2.325  50.494  23.243  1.00 62.50           O  
+ATOM   1559  CB  CYS A 199      -1.585  51.517  20.077  1.00 45.46           C  
+ATOM   1560  SG  CYS A 199      -0.773  53.037  20.597  1.00 46.63           S  
+ATOM   1561  N   GLY A 200      -2.063  48.866  21.684  1.00 48.24           N  
+ATOM   1562  CA  GLY A 200      -1.624  47.821  22.636  1.00 41.49           C  
+ATOM   1563  C   GLY A 200      -2.632  46.656  22.779  1.00 61.74           C  
+ATOM   1564  O   GLY A 200      -3.785  46.747  22.316  1.00 52.12           O  
+ATOM   1565  N   THR A 201      -2.160  45.537  23.421  1.00 59.04           N  
+ATOM   1566  CA  THR A 201      -2.993  44.323  23.692  1.00 34.61           C  
+ATOM   1567  C   THR A 201      -4.108  44.635  24.671  1.00 39.05           C  
+ATOM   1568  O   THR A 201      -3.910  45.258  25.719  1.00 49.68           O  
+ATOM   1569  CB  THR A 201      -2.143  43.211  24.293  1.00 53.24           C  
+ATOM   1570  OG1 THR A 201      -0.797  43.370  23.899  1.00100.00           O  
+ATOM   1571  CG2 THR A 201      -2.667  41.850  23.866  1.00 76.85           C  
+ATOM   1572  N   PRO A 202      -5.244  44.199  24.364  1.00 30.65           N  
+ATOM   1573  CA  PRO A 202      -6.393  44.450  25.216  1.00 35.98           C  
+ATOM   1574  C   PRO A 202      -6.144  44.129  26.712  1.00 32.19           C  
+ATOM   1575  O   PRO A 202      -6.798  44.652  27.572  1.00 36.85           O  
+ATOM   1576  CB  PRO A 202      -7.510  43.550  24.681  1.00 37.38           C  
+ATOM   1577  CG  PRO A 202      -6.920  42.724  23.537  1.00 24.61           C  
+ATOM   1578  CD  PRO A 202      -5.474  43.166  23.364  1.00 21.12           C  
+ATOM   1579  N   GLU A 203      -5.231  43.204  26.983  1.00 58.09           N  
+ATOM   1580  CA  GLU A 203      -4.947  42.721  28.364  1.00 45.19           C  
+ATOM   1581  C   GLU A 203      -4.230  43.741  29.283  1.00 41.20           C  
+ATOM   1582  O   GLU A 203      -4.445  43.755  30.508  1.00 43.05           O  
+ATOM   1583  CB  GLU A 203      -4.191  41.350  28.360  1.00 48.15           C  
+ATOM   1584  CG  GLU A 203      -4.980  40.163  27.702  1.00 19.53           C  
+ATOM   1585  CD  GLU A 203      -4.535  39.836  26.290  1.00 44.46           C  
+ATOM   1586  OE1 GLU A 203      -4.669  40.610  25.350  1.00 42.67           O  
+ATOM   1587  OE2 GLU A 203      -3.997  38.628  26.177  1.00 52.57           O  
+ATOM   1588  N   TYR A 204      -3.340  44.555  28.687  1.00 32.46           N  
+ATOM   1589  CA  TYR A 204      -2.552  45.577  29.424  1.00 21.24           C  
+ATOM   1590  C   TYR A 204      -3.130  47.010  29.297  1.00 43.03           C  
+ATOM   1591  O   TYR A 204      -2.495  48.020  29.728  1.00 32.71           O  
+ATOM   1592  CB  TYR A 204      -1.065  45.553  29.018  1.00  7.70           C  
+ATOM   1593  CG  TYR A 204      -0.405  44.216  29.345  1.00 28.80           C  
+ATOM   1594  CD1 TYR A 204      -0.911  43.014  28.824  1.00 23.22           C  
+ATOM   1595  CD2 TYR A 204       0.714  44.164  30.190  1.00 27.25           C  
+ATOM   1596  CE1 TYR A 204      -0.322  41.779  29.136  1.00 17.84           C  
+ATOM   1597  CE2 TYR A 204       1.278  42.942  30.558  1.00 25.62           C  
+ATOM   1598  CZ  TYR A 204       0.756  41.760  30.033  1.00 45.64           C  
+ATOM   1599  OH  TYR A 204       1.350  40.613  30.344  1.00 37.02           O  
+ATOM   1600  N   LEU A 205      -4.336  47.099  28.707  1.00 22.88           N  
+ATOM   1601  CA  LEU A 205      -4.973  48.371  28.473  1.00 27.56           C  
+ATOM   1602  C   LEU A 205      -5.376  49.087  29.707  1.00 28.16           C  
+ATOM   1603  O   LEU A 205      -6.399  48.767  30.298  1.00 34.25           O  
+ATOM   1604  CB  LEU A 205      -6.178  48.251  27.529  1.00 30.55           C  
+ATOM   1605  CG  LEU A 205      -5.757  47.878  26.124  1.00 22.90           C  
+ATOM   1606  CD1 LEU A 205      -6.976  47.772  25.218  1.00  8.65           C  
+ATOM   1607  CD2 LEU A 205      -4.818  48.940  25.609  1.00  4.67           C  
+ATOM   1608  N   ALA A 206      -4.629  50.132  30.064  1.00 17.89           N  
+ATOM   1609  CA  ALA A 206      -5.055  50.912  31.177  1.00 27.56           C  
+ATOM   1610  C   ALA A 206      -6.487  51.324  30.883  1.00 27.39           C  
+ATOM   1611  O   ALA A 206      -6.864  51.389  29.719  1.00 42.12           O  
+ATOM   1612  CB  ALA A 206      -4.143  52.094  31.359  1.00 28.96           C  
+ATOM   1613  N   PRO A 207      -7.327  51.511  31.906  1.00 31.68           N  
+ATOM   1614  CA  PRO A 207      -8.734  51.836  31.627  1.00 26.23           C  
+ATOM   1615  C   PRO A 207      -8.957  53.242  31.018  1.00 38.21           C  
+ATOM   1616  O   PRO A 207     -10.032  53.585  30.704  1.00 13.85           O  
+ATOM   1617  CB  PRO A 207      -9.514  51.692  32.925  1.00  5.27           C  
+ATOM   1618  CG  PRO A 207      -8.474  51.590  34.028  1.00  9.95           C  
+ATOM   1619  CD  PRO A 207      -7.087  51.481  33.364  1.00 16.84           C  
+ATOM   1620  N   GLU A 208      -7.921  54.054  30.895  1.00 44.61           N  
+ATOM   1621  CA  GLU A 208      -8.089  55.364  30.254  1.00 36.91           C  
+ATOM   1622  C   GLU A 208      -8.358  55.134  28.761  1.00 52.09           C  
+ATOM   1623  O   GLU A 208      -9.454  55.350  28.238  1.00 65.16           O  
+ATOM   1624  CB  GLU A 208      -6.816  56.222  30.403  1.00 39.01           C  
+ATOM   1625  CG  GLU A 208      -6.398  56.541  31.851  1.00 14.98           C  
+ATOM   1626  CD  GLU A 208      -5.421  55.567  32.474  1.00 36.05           C  
+ATOM   1627  OE1 GLU A 208      -4.197  55.707  32.425  1.00 22.03           O  
+ATOM   1628  OE2 GLU A 208      -6.016  54.722  33.277  1.00 30.55           O  
+ATOM   1629  N   ILE A 209      -7.322  54.654  28.121  1.00 17.43           N  
+ATOM   1630  CA  ILE A 209      -7.331  54.225  26.795  1.00  3.62           C  
+ATOM   1631  C   ILE A 209      -8.688  53.650  26.440  1.00 22.74           C  
+ATOM   1632  O   ILE A 209      -9.252  53.975  25.440  1.00 31.42           O  
+ATOM   1633  CB  ILE A 209      -6.345  53.123  26.702  1.00  8.10           C  
+ATOM   1634  CG1 ILE A 209      -5.144  53.420  27.542  1.00 12.02           C  
+ATOM   1635  CG2 ILE A 209      -5.919  52.902  25.322  1.00  9.89           C  
+ATOM   1636  CD1 ILE A 209      -4.118  54.168  26.771  1.00 26.74           C  
+ATOM   1637  N   ILE A 210      -9.207  52.764  27.289  1.00 24.53           N  
+ATOM   1638  CA  ILE A 210     -10.474  52.110  26.973  1.00 16.06           C  
+ATOM   1639  C   ILE A 210     -11.623  53.020  26.783  1.00 20.60           C  
+ATOM   1640  O   ILE A 210     -12.467  52.782  25.953  1.00 35.12           O  
+ATOM   1641  CB  ILE A 210     -10.789  50.898  27.802  1.00 24.85           C  
+ATOM   1642  CG1 ILE A 210      -9.556  49.966  27.815  1.00 19.79           C  
+ATOM   1643  CG2 ILE A 210     -11.994  50.168  27.203  1.00 22.78           C  
+ATOM   1644  CD1 ILE A 210      -9.650  48.852  28.834  1.00 80.29           C  
+ATOM   1645  N   LEU A 211     -11.664  54.083  27.514  1.00 23.32           N  
+ATOM   1646  CA  LEU A 211     -12.724  55.024  27.273  1.00 31.31           C  
+ATOM   1647  C   LEU A 211     -12.303  56.002  26.215  1.00 49.64           C  
+ATOM   1648  O   LEU A 211     -13.128  56.572  25.477  1.00 36.84           O  
+ATOM   1649  CB  LEU A 211     -13.177  55.744  28.530  1.00 21.71           C  
+ATOM   1650  CG  LEU A 211     -13.764  54.795  29.565  1.00 33.84           C  
+ATOM   1651  CD1 LEU A 211     -14.436  53.617  28.894  1.00 44.98           C  
+ATOM   1652  CD2 LEU A 211     -12.691  54.305  30.490  1.00 47.73           C  
+ATOM   1653  N   SER A 212     -10.996  56.142  26.111  1.00 55.85           N  
+ATOM   1654  CA  SER A 212     -10.388  57.069  25.202  1.00 74.06           C  
+ATOM   1655  C   SER A 212     -10.576  58.476  25.654  1.00 83.42           C  
+ATOM   1656  O   SER A 212     -11.342  59.237  25.080  1.00 80.03           O  
+ATOM   1657  CB  SER A 212     -10.799  56.888  23.753  1.00 99.27           C  
+ATOM   1658  OG  SER A 212      -9.655  56.569  22.969  1.00 94.73           O  
+ATOM   1659  N   LYS A 213      -9.875  58.803  26.716  1.00 85.04           N  
+ATOM   1660  CA  LYS A 213      -9.876  60.126  27.251  1.00 79.34           C  
+ATOM   1661  C   LYS A 213      -8.470  60.602  27.541  1.00 58.95           C  
+ATOM   1662  O   LYS A 213      -8.092  60.854  28.679  1.00 70.57           O  
+ATOM   1663  CB  LYS A 213     -10.873  60.376  28.391  1.00 94.71           C  
+ATOM   1664  CG  LYS A 213     -10.800  59.366  29.521  1.00 39.40           C  
+ATOM   1665  CD  LYS A 213     -12.045  59.390  30.417  1.00100.00           C  
+ATOM   1666  CE  LYS A 213     -12.021  58.328  31.532  1.00100.00           C  
+ATOM   1667  NZ  LYS A 213     -13.176  58.427  32.471  1.00100.00           N  
+ATOM   1668  N   GLY A 214      -7.692  60.676  26.470  1.00 51.48           N  
+ATOM   1669  CA  GLY A 214      -6.319  61.154  26.507  1.00 62.24           C  
+ATOM   1670  C   GLY A 214      -5.569  60.707  27.732  1.00 45.34           C  
+ATOM   1671  O   GLY A 214      -5.610  61.333  28.785  1.00 45.07           O  
+ATOM   1672  N   TYR A 215      -4.841  59.665  27.569  1.00 45.87           N  
+ATOM   1673  CA  TYR A 215      -4.089  59.121  28.637  1.00 41.04           C  
+ATOM   1674  C   TYR A 215      -2.717  59.764  28.781  1.00 52.13           C  
+ATOM   1675  O   TYR A 215      -2.439  60.847  28.234  1.00 24.29           O  
+ATOM   1676  CB  TYR A 215      -3.973  57.654  28.459  1.00 47.25           C  
+ATOM   1677  CG  TYR A 215      -3.486  57.272  27.081  1.00 33.34           C  
+ATOM   1678  CD1 TYR A 215      -4.377  57.085  26.018  1.00 10.07           C  
+ATOM   1679  CD2 TYR A 215      -2.127  57.011  26.873  1.00 27.79           C  
+ATOM   1680  CE1 TYR A 215      -3.919  56.601  24.789  1.00  5.35           C  
+ATOM   1681  CE2 TYR A 215      -1.655  56.544  25.653  1.00  5.38           C  
+ATOM   1682  CZ  TYR A 215      -2.552  56.359  24.603  1.00 11.25           C  
+ATOM   1683  OH  TYR A 215      -2.079  55.969  23.370  1.00 18.25           O  
+ATOM   1684  N   ASN A 216      -1.863  59.100  29.540  1.00 50.53           N  
+ATOM   1685  CA  ASN A 216      -0.533  59.576  29.757  1.00 36.77           C  
+ATOM   1686  C   ASN A 216       0.290  58.557  30.423  1.00 40.81           C  
+ATOM   1687  O   ASN A 216      -0.201  57.476  30.767  1.00 57.75           O  
+ATOM   1688  CB  ASN A 216      -0.479  60.932  30.489  1.00 41.23           C  
+ATOM   1689  CG  ASN A 216      -0.759  60.859  31.969  1.00 45.19           C  
+ATOM   1690  OD1 ASN A 216      -0.128  61.586  32.748  1.00 32.38           O  
+ATOM   1691  ND2 ASN A 216      -1.785  60.061  32.351  1.00 20.66           N  
+ATOM   1692  N   LYS A 217       1.557  58.880  30.607  1.00 15.23           N  
+ATOM   1693  CA  LYS A 217       2.506  57.945  31.200  1.00 15.72           C  
+ATOM   1694  C   LYS A 217       1.853  57.000  32.198  1.00 20.18           C  
+ATOM   1695  O   LYS A 217       2.201  55.844  32.269  1.00 20.93           O  
+ATOM   1696  CB  LYS A 217       3.653  58.646  31.814  1.00 22.51           C  
+ATOM   1697  CG  LYS A 217       4.246  59.749  30.940  1.00 35.70           C  
+ATOM   1698  CD  LYS A 217       4.754  60.942  31.780  1.00100.00           C  
+ATOM   1699  CE  LYS A 217       6.006  61.625  31.225  1.00100.00           C  
+ATOM   1700  NZ  LYS A 217       6.573  62.638  32.154  1.00100.00           N  
+ATOM   1701  N   ALA A 218       0.879  57.520  32.941  1.00 13.48           N  
+ATOM   1702  CA  ALA A 218       0.108  56.751  33.912  1.00 14.41           C  
+ATOM   1703  C   ALA A 218      -0.392  55.429  33.384  1.00 23.90           C  
+ATOM   1704  O   ALA A 218      -0.525  54.469  34.145  1.00 44.37           O  
+ATOM   1705  CB  ALA A 218      -1.056  57.551  34.380  1.00 24.30           C  
+ATOM   1706  N   VAL A 219      -0.764  55.401  32.109  1.00 23.79           N  
+ATOM   1707  CA  VAL A 219      -1.213  54.174  31.522  1.00 24.96           C  
+ATOM   1708  C   VAL A 219      -0.097  53.141  31.608  1.00 36.18           C  
+ATOM   1709  O   VAL A 219      -0.346  51.945  31.742  1.00 42.60           O  
+ATOM   1710  CB  VAL A 219      -1.684  54.341  30.094  1.00 35.01           C  
+ATOM   1711  CG1 VAL A 219      -2.875  55.277  30.048  1.00 37.30           C  
+ATOM   1712  CG2 VAL A 219      -0.542  54.881  29.208  1.00 26.76           C  
+ATOM   1713  N   ASP A 220       1.149  53.648  31.576  1.00 25.85           N  
+ATOM   1714  CA  ASP A 220       2.348  52.812  31.678  1.00 27.94           C  
+ATOM   1715  C   ASP A 220       2.410  52.059  33.018  1.00 37.77           C  
+ATOM   1716  O   ASP A 220       2.247  50.839  33.065  1.00 48.27           O  
+ATOM   1717  CB  ASP A 220       3.655  53.620  31.398  1.00 33.04           C  
+ATOM   1718  CG  ASP A 220       4.181  53.430  30.001  1.00 36.41           C  
+ATOM   1719  OD1 ASP A 220       3.906  52.466  29.340  1.00 41.82           O  
+ATOM   1720  OD2 ASP A 220       5.039  54.366  29.624  1.00 31.21           O  
+ATOM   1721  N   TRP A 221       2.595  52.815  34.120  1.00 39.07           N  
+ATOM   1722  CA  TRP A 221       2.633  52.251  35.472  1.00  3.10           C  
+ATOM   1723  C   TRP A 221       1.476  51.226  35.668  1.00 32.17           C  
+ATOM   1724  O   TRP A 221       1.658  50.126  36.219  1.00 26.56           O  
+ATOM   1725  CB  TRP A 221       2.563  53.350  36.477  1.00  2.35           C  
+ATOM   1726  CG  TRP A 221       3.711  54.310  36.369  1.00  8.14           C  
+ATOM   1727  CD1 TRP A 221       3.614  55.648  36.246  1.00 18.09           C  
+ATOM   1728  CD2 TRP A 221       5.089  54.035  36.542  1.00  1.00           C  
+ATOM   1729  NE1 TRP A 221       4.853  56.222  36.261  1.00 25.41           N  
+ATOM   1730  CE2 TRP A 221       5.776  55.254  36.454  1.00 10.26           C  
+ATOM   1731  CE3 TRP A 221       5.773  52.921  36.818  1.00  2.72           C  
+ATOM   1732  CZ2 TRP A 221       7.147  55.340  36.535  1.00  2.07           C  
+ATOM   1733  CZ3 TRP A 221       7.132  52.978  36.853  1.00 10.11           C  
+ATOM   1734  CH2 TRP A 221       7.814  54.186  36.748  1.00  2.57           C  
+ATOM   1735  N   TRP A 222       0.297  51.566  35.154  1.00  1.00           N  
+ATOM   1736  CA  TRP A 222      -0.782  50.629  35.194  1.00  9.10           C  
+ATOM   1737  C   TRP A 222      -0.373  49.276  34.608  1.00 26.66           C  
+ATOM   1738  O   TRP A 222      -0.756  48.269  35.099  1.00 32.50           O  
+ATOM   1739  CB  TRP A 222      -1.987  51.144  34.444  1.00 15.06           C  
+ATOM   1740  CG  TRP A 222      -3.026  50.080  34.233  1.00 20.94           C  
+ATOM   1741  CD1 TRP A 222      -2.999  49.087  33.309  1.00 17.65           C  
+ATOM   1742  CD2 TRP A 222      -4.276  49.929  34.951  1.00 30.53           C  
+ATOM   1743  NE1 TRP A 222      -4.142  48.311  33.397  1.00 17.34           N  
+ATOM   1744  CE2 TRP A 222      -4.965  48.829  34.368  1.00 29.40           C  
+ATOM   1745  CE3 TRP A 222      -4.887  50.632  36.017  1.00 32.98           C  
+ATOM   1746  CZ2 TRP A 222      -6.229  48.408  34.839  1.00 20.57           C  
+ATOM   1747  CZ3 TRP A 222      -6.126  50.208  36.485  1.00 32.67           C  
+ATOM   1748  CH2 TRP A 222      -6.793  49.112  35.900  1.00 28.80           C  
+ATOM   1749  N   ALA A 223       0.306  49.291  33.448  1.00 36.66           N  
+ATOM   1750  CA  ALA A 223       0.753  48.056  32.788  1.00 14.47           C  
+ATOM   1751  C   ALA A 223       1.825  47.348  33.576  1.00 30.01           C  
+ATOM   1752  O   ALA A 223       2.013  46.125  33.467  1.00 31.81           O  
+ATOM   1753  CB  ALA A 223       1.233  48.322  31.419  1.00  5.94           C  
+ATOM   1754  N   LEU A 224       2.517  48.100  34.390  1.00 42.80           N  
+ATOM   1755  CA  LEU A 224       3.509  47.512  35.257  1.00 35.45           C  
+ATOM   1756  C   LEU A 224       2.824  46.521  36.263  1.00 35.63           C  
+ATOM   1757  O   LEU A 224       3.362  45.493  36.610  1.00 28.13           O  
+ATOM   1758  CB  LEU A 224       4.393  48.599  35.970  1.00 16.48           C  
+ATOM   1759  CG  LEU A 224       5.496  48.002  36.861  1.00 35.35           C  
+ATOM   1760  CD1 LEU A 224       6.073  46.749  36.228  1.00 18.30           C  
+ATOM   1761  CD2 LEU A 224       6.623  49.005  37.121  1.00 17.75           C  
+ATOM   1762  N   GLY A 225       1.591  46.831  36.655  1.00 13.18           N  
+ATOM   1763  CA  GLY A 225       0.866  46.006  37.602  1.00  1.00           C  
+ATOM   1764  C   GLY A 225       0.410  44.767  36.981  1.00 10.55           C  
+ATOM   1765  O   GLY A 225       0.521  43.684  37.563  1.00 23.49           O  
+ATOM   1766  N   VAL A 226      -0.136  44.916  35.778  1.00 28.55           N  
+ATOM   1767  CA  VAL A 226      -0.583  43.787  35.001  1.00 22.69           C  
+ATOM   1768  C   VAL A 226       0.614  42.903  34.737  1.00 11.79           C  
+ATOM   1769  O   VAL A 226       0.562  41.671  34.879  1.00 19.10           O  
+ATOM   1770  CB  VAL A 226      -1.297  44.198  33.683  1.00 26.32           C  
+ATOM   1771  CG1 VAL A 226      -1.684  42.972  32.884  1.00 29.38           C  
+ATOM   1772  CG2 VAL A 226      -2.559  45.034  33.972  1.00 18.85           C  
+ATOM   1773  N   LEU A 227       1.721  43.542  34.503  1.00  1.00           N  
+ATOM   1774  CA  LEU A 227       2.955  42.836  34.294  1.00  1.00           C  
+ATOM   1775  C   LEU A 227       3.285  41.958  35.435  1.00 21.14           C  
+ATOM   1776  O   LEU A 227       3.460  40.739  35.306  1.00 35.02           O  
+ATOM   1777  CB  LEU A 227       4.105  43.802  34.083  1.00  7.81           C  
+ATOM   1778  CG  LEU A 227       5.358  43.044  33.649  1.00 36.02           C  
+ATOM   1779  CD1 LEU A 227       4.959  41.998  32.597  1.00  4.70           C  
+ATOM   1780  CD2 LEU A 227       6.414  43.988  33.076  1.00  1.61           C  
+ATOM   1781  N   ILE A 228       3.379  42.583  36.576  1.00 39.64           N  
+ATOM   1782  CA  ILE A 228       3.686  41.915  37.797  1.00 28.96           C  
+ATOM   1783  C   ILE A 228       2.668  40.867  38.194  1.00 30.72           C  
+ATOM   1784  O   ILE A 228       2.999  39.687  38.474  1.00 27.57           O  
+ATOM   1785  CB  ILE A 228       3.851  42.874  38.885  1.00 23.86           C  
+ATOM   1786  CG1 ILE A 228       5.191  43.633  38.682  1.00 19.16           C  
+ATOM   1787  CG2 ILE A 228       3.847  42.068  40.149  1.00 10.69           C  
+ATOM   1788  CD1 ILE A 228       5.266  44.936  39.455  1.00  1.00           C  
+ATOM   1789  N   TYR A 229       1.430  41.267  38.251  1.00  6.94           N  
+ATOM   1790  CA  TYR A 229       0.452  40.295  38.638  1.00  9.62           C  
+ATOM   1791  C   TYR A 229       0.694  39.008  37.900  1.00  4.49           C  
+ATOM   1792  O   TYR A 229       0.790  37.943  38.471  1.00 44.91           O  
+ATOM   1793  CB  TYR A 229      -0.950  40.794  38.407  1.00  1.00           C  
+ATOM   1794  CG  TYR A 229      -2.028  39.791  38.782  1.00 14.87           C  
+ATOM   1795  CD1 TYR A 229      -2.181  38.574  38.107  1.00 22.61           C  
+ATOM   1796  CD2 TYR A 229      -2.994  40.134  39.727  1.00 33.88           C  
+ATOM   1797  CE1 TYR A 229      -3.230  37.701  38.397  1.00 30.13           C  
+ATOM   1798  CE2 TYR A 229      -4.064  39.285  40.021  1.00 40.36           C  
+ATOM   1799  CZ  TYR A 229      -4.186  38.069  39.343  1.00 21.02           C  
+ATOM   1800  OH  TYR A 229      -5.244  37.219  39.622  1.00 22.89           O  
+ATOM   1801  N   GLU A 230       0.690  39.110  36.631  1.00 17.01           N  
+ATOM   1802  CA  GLU A 230       0.865  37.994  35.815  1.00  3.90           C  
+ATOM   1803  C   GLU A 230       2.188  37.321  36.044  1.00 23.14           C  
+ATOM   1804  O   GLU A 230       2.240  36.117  36.131  1.00 25.97           O  
+ATOM   1805  CB  GLU A 230       0.654  38.362  34.388  1.00  2.54           C  
+ATOM   1806  CG  GLU A 230       1.280  37.394  33.403  1.00 55.32           C  
+ATOM   1807  CD  GLU A 230       0.960  37.760  31.988  1.00 94.07           C  
+ATOM   1808  OE1 GLU A 230       0.722  38.888  31.648  1.00 12.54           O  
+ATOM   1809  OE2 GLU A 230       0.851  36.719  31.192  1.00 42.54           O  
+ATOM   1810  N   MET A 231       3.287  38.103  36.163  1.00  2.77           N  
+ATOM   1811  CA  MET A 231       4.588  37.467  36.398  1.00  1.84           C  
+ATOM   1812  C   MET A 231       4.499  36.540  37.554  1.00 24.12           C  
+ATOM   1813  O   MET A 231       5.173  35.507  37.615  1.00 23.33           O  
+ATOM   1814  CB  MET A 231       5.673  38.527  36.759  1.00 15.80           C  
+ATOM   1815  CG  MET A 231       6.359  39.098  35.570  1.00 11.57           C  
+ATOM   1816  SD  MET A 231       8.019  39.652  35.924  1.00 18.52           S  
+ATOM   1817  CE  MET A 231       7.588  41.137  36.779  1.00 11.21           C  
+ATOM   1818  N   ALA A 232       3.709  36.972  38.535  1.00 25.72           N  
+ATOM   1819  CA  ALA A 232       3.604  36.292  39.798  1.00 32.12           C  
+ATOM   1820  C   ALA A 232       2.485  35.281  39.943  1.00 47.43           C  
+ATOM   1821  O   ALA A 232       2.398  34.594  40.989  1.00 69.41           O  
+ATOM   1822  CB  ALA A 232       3.548  37.293  40.930  1.00 29.26           C  
+ATOM   1823  N   ALA A 233       1.630  35.172  38.923  1.00 38.21           N  
+ATOM   1824  CA  ALA A 233       0.455  34.273  38.968  1.00 12.74           C  
+ATOM   1825  C   ALA A 233       0.328  33.347  37.738  1.00 25.48           C  
+ATOM   1826  O   ALA A 233      -0.400  32.356  37.773  1.00 27.21           O  
+ATOM   1827  CB  ALA A 233      -0.774  35.164  39.012  1.00  3.21           C  
+ATOM   1828  N   GLY A 234       1.070  33.686  36.682  1.00 18.33           N  
+ATOM   1829  CA  GLY A 234       0.868  33.132  35.414  1.00 19.43           C  
+ATOM   1830  C   GLY A 234      -0.240  34.020  34.855  1.00 18.86           C  
+ATOM   1831  O   GLY A 234      -0.036  35.194  34.606  1.00 58.26           O  
+ATOM   1832  N   TYR A 235      -1.408  33.577  34.917  1.00  8.50           N  
+ATOM   1833  CA  TYR A 235      -2.523  34.408  34.480  1.00 17.33           C  
+ATOM   1834  C   TYR A 235      -2.386  35.858  34.844  1.00 42.46           C  
+ATOM   1835  O   TYR A 235      -1.719  36.228  35.799  1.00 86.51           O  
+ATOM   1836  CB  TYR A 235      -3.896  33.871  34.957  1.00 22.53           C  
+ATOM   1837  CG  TYR A 235      -4.005  33.550  36.454  1.00 26.26           C  
+ATOM   1838  CD1 TYR A 235      -3.250  32.536  37.049  1.00 43.89           C  
+ATOM   1839  CD2 TYR A 235      -4.950  34.197  37.243  1.00 44.28           C  
+ATOM   1840  CE1 TYR A 235      -3.393  32.211  38.398  1.00 63.07           C  
+ATOM   1841  CE2 TYR A 235      -5.132  33.862  38.585  1.00 54.80           C  
+ATOM   1842  CZ  TYR A 235      -4.356  32.860  39.159  1.00 77.83           C  
+ATOM   1843  OH  TYR A 235      -4.507  32.540  40.472  1.00100.00           O  
+ATOM   1844  N   PRO A 236      -3.095  36.686  34.085  1.00 49.14           N  
+ATOM   1845  CA  PRO A 236      -3.127  38.125  34.278  1.00 45.68           C  
+ATOM   1846  C   PRO A 236      -4.443  38.523  34.932  1.00 39.93           C  
+ATOM   1847  O   PRO A 236      -5.423  37.778  34.820  1.00 26.72           O  
+ATOM   1848  CB  PRO A 236      -3.109  38.721  32.868  1.00 46.63           C  
+ATOM   1849  CG  PRO A 236      -3.561  37.614  31.925  1.00 38.45           C  
+ATOM   1850  CD  PRO A 236      -3.542  36.312  32.730  1.00 41.22           C  
+ATOM   1851  N   PRO A 237      -4.467  39.740  35.559  1.00 20.50           N  
+ATOM   1852  CA  PRO A 237      -5.616  40.248  36.257  1.00 10.92           C  
+ATOM   1853  C   PRO A 237      -6.874  40.213  35.465  1.00 44.81           C  
+ATOM   1854  O   PRO A 237      -7.871  39.649  35.857  1.00 59.47           O  
+ATOM   1855  CB  PRO A 237      -5.296  41.692  36.662  1.00 22.61           C  
+ATOM   1856  CG  PRO A 237      -3.852  41.965  36.255  1.00 28.83           C  
+ATOM   1857  CD  PRO A 237      -3.344  40.728  35.541  1.00  5.67           C  
+ATOM   1858  N   PHE A 238      -6.867  40.899  34.338  1.00 51.71           N  
+ATOM   1859  CA  PHE A 238      -8.011  40.951  33.491  1.00 42.66           C  
+ATOM   1860  C   PHE A 238      -7.827  40.137  32.299  1.00 35.92           C  
+ATOM   1861  O   PHE A 238      -6.828  40.256  31.614  1.00 51.49           O  
+ATOM   1862  CB  PHE A 238      -8.372  42.394  33.120  1.00 37.75           C  
+ATOM   1863  CG  PHE A 238      -8.166  43.252  34.306  1.00 34.49           C  
+ATOM   1864  CD1 PHE A 238      -9.133  43.314  35.306  1.00 26.93           C  
+ATOM   1865  CD2 PHE A 238      -6.952  43.909  34.520  1.00 17.33           C  
+ATOM   1866  CE1 PHE A 238      -8.926  44.052  36.460  1.00 21.94           C  
+ATOM   1867  CE2 PHE A 238      -6.717  44.652  35.671  1.00 20.73           C  
+ATOM   1868  CZ  PHE A 238      -7.712  44.703  36.637  1.00 17.15           C  
+ATOM   1869  N   PHE A 239      -8.772  39.261  32.069  1.00 35.37           N  
+ATOM   1870  CA  PHE A 239      -8.704  38.394  30.964  1.00 35.39           C  
+ATOM   1871  C   PHE A 239      -9.969  37.548  30.779  1.00 29.02           C  
+ATOM   1872  O   PHE A 239     -10.467  36.946  31.699  1.00 34.70           O  
+ATOM   1873  CB  PHE A 239      -7.447  37.551  30.951  1.00 38.20           C  
+ATOM   1874  CG  PHE A 239      -7.680  36.217  31.580  1.00 72.08           C  
+ATOM   1875  CD1 PHE A 239      -7.560  36.046  32.964  1.00 85.63           C  
+ATOM   1876  CD2 PHE A 239      -8.081  35.126  30.801  1.00 80.00           C  
+ATOM   1877  CE1 PHE A 239      -7.792  34.812  33.560  1.00 93.33           C  
+ATOM   1878  CE2 PHE A 239      -8.349  33.889  31.375  1.00 85.71           C  
+ATOM   1879  CZ  PHE A 239      -8.186  33.739  32.757  1.00 95.57           C  
+ATOM   1880  N   ALA A 240     -10.473  37.591  29.531  1.00 35.47           N  
+ATOM   1881  CA  ALA A 240     -11.618  36.873  29.049  1.00 30.22           C  
+ATOM   1882  C   ALA A 240     -11.281  36.301  27.656  1.00 81.06           C  
+ATOM   1883  O   ALA A 240     -10.116  36.244  27.265  1.00 94.01           O  
+ATOM   1884  CB  ALA A 240     -12.847  37.769  28.996  1.00 26.25           C  
+ATOM   1885  N   ASP A 241     -12.295  35.850  26.928  1.00 83.64           N  
+ATOM   1886  CA  ASP A 241     -12.095  35.218  25.621  1.00 76.88           C  
+ATOM   1887  C   ASP A 241     -11.989  36.217  24.513  1.00 73.72           C  
+ATOM   1888  O   ASP A 241     -11.023  36.231  23.716  1.00 88.55           O  
+ATOM   1889  CB  ASP A 241     -13.235  34.266  25.332  1.00 83.49           C  
+ATOM   1890  CG  ASP A 241     -12.977  33.347  24.193  1.00100.00           C  
+ATOM   1891  OD1 ASP A 241     -13.035  33.701  23.014  1.00100.00           O  
+ATOM   1892  OD2 ASP A 241     -12.633  32.149  24.582  1.00100.00           O  
+ATOM   1893  N   GLN A 242     -13.004  36.989  24.410  1.00 61.06           N  
+ATOM   1894  CA  GLN A 242     -13.036  37.984  23.415  1.00 69.49           C  
+ATOM   1895  C   GLN A 242     -12.948  39.380  23.995  1.00 74.34           C  
+ATOM   1896  O   GLN A 242     -13.640  39.718  24.962  1.00 73.35           O  
+ATOM   1897  CB  GLN A 242     -14.207  37.827  22.456  1.00 84.56           C  
+ATOM   1898  CG  GLN A 242     -13.728  37.751  20.980  1.00100.00           C  
+ATOM   1899  CD  GLN A 242     -14.868  37.638  19.956  1.00100.00           C  
+ATOM   1900  OE1 GLN A 242     -14.863  38.320  18.897  1.00100.00           O  
+ATOM   1901  NE2 GLN A 242     -15.845  36.758  20.244  1.00100.00           N  
+ATOM   1902  N   PRO A 243     -12.128  40.194  23.350  1.00 69.42           N  
+ATOM   1903  CA  PRO A 243     -11.805  41.564  23.755  1.00 65.54           C  
+ATOM   1904  C   PRO A 243     -12.885  42.400  24.414  1.00 58.38           C  
+ATOM   1905  O   PRO A 243     -12.670  42.935  25.487  1.00 52.00           O  
+ATOM   1906  CB  PRO A 243     -11.259  42.271  22.547  1.00 61.87           C  
+ATOM   1907  CG  PRO A 243     -11.098  41.230  21.462  1.00 51.50           C  
+ATOM   1908  CD  PRO A 243     -11.683  39.920  21.981  1.00 54.32           C  
+ATOM   1909  N   ILE A 244     -13.994  42.604  23.772  1.00 46.95           N  
+ATOM   1910  CA  ILE A 244     -14.973  43.419  24.425  1.00 44.48           C  
+ATOM   1911  C   ILE A 244     -15.170  43.036  25.875  1.00 17.48           C  
+ATOM   1912  O   ILE A 244     -15.272  43.882  26.739  1.00 33.93           O  
+ATOM   1913  CB  ILE A 244     -16.271  43.508  23.694  1.00 57.40           C  
+ATOM   1914  CG1 ILE A 244     -16.372  44.888  23.064  1.00 81.74           C  
+ATOM   1915  CG2 ILE A 244     -17.428  43.289  24.658  1.00 43.82           C  
+ATOM   1916  CD1 ILE A 244     -17.815  45.351  22.852  1.00100.00           C  
+ATOM   1917  N   GLN A 245     -15.248  41.742  26.136  1.00 37.93           N  
+ATOM   1918  CA  GLN A 245     -15.472  41.279  27.492  1.00 47.28           C  
+ATOM   1919  C   GLN A 245     -14.397  41.828  28.436  1.00 48.63           C  
+ATOM   1920  O   GLN A 245     -14.692  42.640  29.310  1.00 51.84           O  
+ATOM   1921  CB  GLN A 245     -15.635  39.722  27.614  1.00 58.21           C  
+ATOM   1922  CG  GLN A 245     -16.770  39.083  26.732  1.00 36.49           C  
+ATOM   1923  CD  GLN A 245     -16.222  38.294  25.517  1.00100.00           C  
+ATOM   1924  OE1 GLN A 245     -16.678  38.478  24.356  1.00100.00           O  
+ATOM   1925  NE2 GLN A 245     -15.268  37.380  25.788  1.00 76.30           N  
+ATOM   1926  N   ILE A 246     -13.128  41.418  28.181  1.00 35.09           N  
+ATOM   1927  CA  ILE A 246     -11.924  41.901  28.925  1.00 25.58           C  
+ATOM   1928  C   ILE A 246     -12.005  43.387  29.179  1.00 48.62           C  
+ATOM   1929  O   ILE A 246     -11.351  43.916  30.081  1.00 49.24           O  
+ATOM   1930  CB  ILE A 246     -10.650  41.670  28.097  1.00 27.17           C  
+ATOM   1931  CG1 ILE A 246     -10.526  40.247  27.625  1.00  9.17           C  
+ATOM   1932  CG2 ILE A 246      -9.418  42.073  28.860  1.00 29.45           C  
+ATOM   1933  CD1 ILE A 246      -9.655  40.152  26.398  1.00 54.17           C  
+ATOM   1934  N   TYR A 247     -12.741  44.073  28.284  1.00 56.31           N  
+ATOM   1935  CA  TYR A 247     -12.911  45.507  28.333  1.00 40.81           C  
+ATOM   1936  C   TYR A 247     -13.729  45.978  29.556  1.00 34.21           C  
+ATOM   1937  O   TYR A 247     -13.184  46.614  30.461  1.00 37.33           O  
+ATOM   1938  CB  TYR A 247     -13.425  46.080  26.995  1.00 41.82           C  
+ATOM   1939  CG  TYR A 247     -12.359  46.125  25.945  1.00 19.18           C  
+ATOM   1940  CD1 TYR A 247     -11.026  46.341  26.295  1.00 30.01           C  
+ATOM   1941  CD2 TYR A 247     -12.679  45.980  24.598  1.00 37.71           C  
+ATOM   1942  CE1 TYR A 247     -10.023  46.370  25.324  1.00 56.11           C  
+ATOM   1943  CE2 TYR A 247     -11.698  46.048  23.608  1.00 48.31           C  
+ATOM   1944  CZ  TYR A 247     -10.369  46.229  23.978  1.00 39.68           C  
+ATOM   1945  OH  TYR A 247      -9.420  46.264  23.032  1.00 36.03           O  
+ATOM   1946  N   GLU A 248     -15.017  45.616  29.624  1.00 27.22           N  
+ATOM   1947  CA  GLU A 248     -15.811  45.986  30.800  1.00 48.28           C  
+ATOM   1948  C   GLU A 248     -15.128  45.565  32.140  1.00 59.74           C  
+ATOM   1949  O   GLU A 248     -15.153  46.282  33.144  1.00 74.62           O  
+ATOM   1950  CB  GLU A 248     -17.267  45.492  30.727  1.00 59.09           C  
+ATOM   1951  CG  GLU A 248     -17.433  44.079  30.117  1.00100.00           C  
+ATOM   1952  CD  GLU A 248     -18.694  43.387  30.596  1.00100.00           C  
+ATOM   1953  OE1 GLU A 248     -18.859  43.063  31.758  1.00 48.70           O  
+ATOM   1954  OE2 GLU A 248     -19.601  43.211  29.637  1.00100.00           O  
+ATOM   1955  N   LYS A 249     -14.497  44.417  32.115  1.00 41.25           N  
+ATOM   1956  CA  LYS A 249     -13.784  43.874  33.260  1.00 38.18           C  
+ATOM   1957  C   LYS A 249     -12.849  44.898  33.864  1.00 27.78           C  
+ATOM   1958  O   LYS A 249     -12.887  45.170  35.033  1.00 27.30           O  
+ATOM   1959  CB  LYS A 249     -12.964  42.658  32.804  1.00 27.70           C  
+ATOM   1960  CG  LYS A 249     -13.141  41.441  33.680  1.00 16.18           C  
+ATOM   1961  CD  LYS A 249     -13.292  40.148  32.877  1.00 74.05           C  
+ATOM   1962  CE  LYS A 249     -14.752  39.786  32.593  1.00100.00           C  
+ATOM   1963  NZ  LYS A 249     -15.514  40.860  31.920  1.00100.00           N  
+ATOM   1964  N   ILE A 250     -11.965  45.405  33.007  1.00 54.72           N  
+ATOM   1965  CA  ILE A 250     -10.921  46.372  33.340  1.00 37.51           C  
+ATOM   1966  C   ILE A 250     -11.445  47.619  34.029  1.00 27.25           C  
+ATOM   1967  O   ILE A 250     -10.879  48.061  34.975  1.00 32.69           O  
+ATOM   1968  CB  ILE A 250     -10.131  46.791  32.082  1.00 28.04           C  
+ATOM   1969  CG1 ILE A 250      -9.374  45.611  31.467  1.00 20.29           C  
+ATOM   1970  CG2 ILE A 250      -9.181  47.912  32.419  1.00 16.57           C  
+ATOM   1971  CD1 ILE A 250      -8.109  46.035  30.728  1.00 31.10           C  
+ATOM   1972  N   VAL A 251     -12.507  48.203  33.488  1.00 38.74           N  
+ATOM   1973  CA  VAL A 251     -13.059  49.451  34.025  1.00 19.67           C  
+ATOM   1974  C   VAL A 251     -13.701  49.279  35.348  1.00 39.44           C  
+ATOM   1975  O   VAL A 251     -13.671  50.183  36.182  1.00 82.03           O  
+ATOM   1976  CB  VAL A 251     -14.020  50.115  33.072  1.00 23.02           C  
+ATOM   1977  CG1 VAL A 251     -14.467  51.406  33.683  1.00 39.50           C  
+ATOM   1978  CG2 VAL A 251     -13.349  50.393  31.733  1.00 18.40           C  
+ATOM   1979  N   SER A 252     -14.359  48.129  35.545  1.00 58.16           N  
+ATOM   1980  CA  SER A 252     -14.982  47.850  36.837  1.00 44.90           C  
+ATOM   1981  C   SER A 252     -13.899  47.859  37.855  1.00 38.67           C  
+ATOM   1982  O   SER A 252     -14.026  48.464  38.926  1.00 60.15           O  
+ATOM   1983  CB  SER A 252     -15.614  46.526  36.845  1.00 26.35           C  
+ATOM   1984  OG  SER A 252     -14.602  45.594  37.109  1.00 13.74           O  
+ATOM   1985  N   GLY A 253     -12.768  47.212  37.454  1.00 29.98           N  
+ATOM   1986  CA  GLY A 253     -11.524  47.168  38.226  1.00 34.70           C  
+ATOM   1987  C   GLY A 253     -11.509  46.161  39.392  1.00 64.69           C  
+ATOM   1988  O   GLY A 253     -10.631  46.215  40.246  1.00 82.58           O  
+ATOM   1989  N   LYS A 254     -12.469  45.262  39.452  1.00 48.81           N  
+ATOM   1990  CA  LYS A 254     -12.432  44.309  40.528  1.00 51.50           C  
+ATOM   1991  C   LYS A 254     -11.338  43.300  40.284  1.00 60.34           C  
+ATOM   1992  O   LYS A 254     -11.455  42.445  39.379  1.00 40.92           O  
+ATOM   1993  CB  LYS A 254     -13.753  43.584  40.752  1.00 59.12           C  
+ATOM   1994  CG  LYS A 254     -14.988  44.455  40.586  1.00 90.36           C  
+ATOM   1995  CD  LYS A 254     -16.284  43.705  40.949  1.00100.00           C  
+ATOM   1996  CE  LYS A 254     -17.464  44.020  40.017  1.00100.00           C  
+ATOM   1997  NZ  LYS A 254     -17.321  43.398  38.660  1.00 48.85           N  
+ATOM   1998  N   VAL A 255     -10.247  43.420  41.064  1.00 54.89           N  
+ATOM   1999  CA  VAL A 255      -9.138  42.472  40.985  1.00 48.75           C  
+ATOM   2000  C   VAL A 255      -9.186  41.474  42.141  1.00 64.19           C  
+ATOM   2001  O   VAL A 255      -9.412  41.853  43.298  1.00 54.42           O  
+ATOM   2002  CB  VAL A 255      -7.780  43.163  40.963  1.00 40.40           C  
+ATOM   2003  CG1 VAL A 255      -6.648  42.150  40.728  1.00 29.12           C  
+ATOM   2004  CG2 VAL A 255      -7.751  44.197  39.890  1.00 48.95           C  
+ATOM   2005  N   ARG A 256      -8.962  40.204  41.804  1.00 49.22           N  
+ATOM   2006  CA  ARG A 256      -8.892  39.103  42.756  1.00 31.93           C  
+ATOM   2007  C   ARG A 256      -7.443  38.674  42.960  1.00 36.00           C  
+ATOM   2008  O   ARG A 256      -6.738  38.367  41.992  1.00 52.30           O  
+ATOM   2009  CB  ARG A 256      -9.712  37.894  42.253  1.00 33.49           C  
+ATOM   2010  CG  ARG A 256      -9.952  36.811  43.336  1.00100.00           C  
+ATOM   2011  CD  ARG A 256     -10.924  35.691  42.898  1.00100.00           C  
+ATOM   2012  NE  ARG A 256     -10.255  34.538  42.278  1.00100.00           N  
+ATOM   2013  CZ  ARG A 256      -9.126  33.984  42.731  1.00100.00           C  
+ATOM   2014  NH1 ARG A 256      -8.520  34.415  43.830  1.00100.00           N  
+ATOM   2015  NH2 ARG A 256      -8.606  32.946  42.075  1.00100.00           N  
+ATOM   2016  N   PHE A 257      -6.985  38.629  44.196  1.00 10.49           N  
+ATOM   2017  CA  PHE A 257      -5.647  38.142  44.408  1.00 14.24           C  
+ATOM   2018  C   PHE A 257      -5.566  36.669  44.725  1.00 32.56           C  
+ATOM   2019  O   PHE A 257      -6.290  36.129  45.542  1.00 23.29           O  
+ATOM   2020  CB  PHE A 257      -4.877  38.938  45.379  1.00 14.14           C  
+ATOM   2021  CG  PHE A 257      -4.773  40.309  44.910  1.00 28.03           C  
+ATOM   2022  CD1 PHE A 257      -3.770  40.675  44.020  1.00 38.25           C  
+ATOM   2023  CD2 PHE A 257      -5.716  41.259  45.281  1.00 29.65           C  
+ATOM   2024  CE1 PHE A 257      -3.662  41.986  43.559  1.00 43.41           C  
+ATOM   2025  CE2 PHE A 257      -5.625  42.575  44.826  1.00 44.80           C  
+ATOM   2026  CZ  PHE A 257      -4.594  42.937  43.960  1.00 31.36           C  
+ATOM   2027  N   PRO A 258      -4.652  36.018  44.120  1.00 28.18           N  
+ATOM   2028  CA  PRO A 258      -4.483  34.691  44.468  1.00 24.89           C  
+ATOM   2029  C   PRO A 258      -4.029  34.626  45.936  1.00 46.01           C  
+ATOM   2030  O   PRO A 258      -3.337  35.553  46.451  1.00 20.14           O  
+ATOM   2031  CB  PRO A 258      -3.419  34.112  43.551  1.00 16.31           C  
+ATOM   2032  CG  PRO A 258      -2.941  35.239  42.668  1.00 31.72           C  
+ATOM   2033  CD  PRO A 258      -3.693  36.460  43.101  1.00 28.73           C  
+ATOM   2034  N   SER A 259      -4.425  33.538  46.599  1.00 33.33           N  
+ATOM   2035  CA  SER A 259      -4.084  33.291  47.992  1.00 36.48           C  
+ATOM   2036  C   SER A 259      -2.576  33.443  48.317  1.00 40.03           C  
+ATOM   2037  O   SER A 259      -2.205  33.960  49.392  1.00 47.91           O  
+ATOM   2038  CB  SER A 259      -4.619  31.937  48.446  1.00 17.68           C  
+ATOM   2039  OG  SER A 259      -4.924  31.139  47.303  1.00 46.36           O  
+ATOM   2040  N   HIS A 260      -1.706  32.963  47.394  1.00 14.93           N  
+ATOM   2041  CA  HIS A 260      -0.258  32.988  47.625  1.00 17.13           C  
+ATOM   2042  C   HIS A 260       0.427  34.376  47.493  1.00 43.44           C  
+ATOM   2043  O   HIS A 260       1.656  34.504  47.640  1.00 43.90           O  
+ATOM   2044  CB  HIS A 260       0.485  31.909  46.864  1.00 19.90           C  
+ATOM   2045  CG  HIS A 260       0.420  32.114  45.424  1.00 28.33           C  
+ATOM   2046  ND1 HIS A 260       1.526  32.556  44.708  1.00 35.48           N  
+ATOM   2047  CD2 HIS A 260      -0.620  31.980  44.572  1.00 15.07           C  
+ATOM   2048  CE1 HIS A 260       1.134  32.680  43.447  1.00 19.51           C  
+ATOM   2049  NE2 HIS A 260      -0.138  32.327  43.328  1.00 15.32           N  
+ATOM   2050  N   PHE A 261      -0.333  35.410  47.237  1.00 21.63           N  
+ATOM   2051  CA  PHE A 261       0.303  36.683  47.115  1.00 27.01           C  
+ATOM   2052  C   PHE A 261       0.804  37.157  48.391  1.00 28.96           C  
+ATOM   2053  O   PHE A 261       0.067  37.276  49.334  1.00 25.73           O  
+ATOM   2054  CB  PHE A 261      -0.606  37.734  46.572  1.00 33.53           C  
+ATOM   2055  CG  PHE A 261      -0.566  37.874  45.088  1.00 51.11           C  
+ATOM   2056  CD1 PHE A 261      -0.421  36.762  44.251  1.00 51.55           C  
+ATOM   2057  CD2 PHE A 261      -0.800  39.118  44.510  1.00 51.97           C  
+ATOM   2058  CE1 PHE A 261      -0.464  36.896  42.866  1.00 24.41           C  
+ATOM   2059  CE2 PHE A 261      -0.876  39.266  43.130  1.00 22.18           C  
+ATOM   2060  CZ  PHE A 261      -0.677  38.154  42.317  1.00  9.67           C  
+ATOM   2061  N   SER A 262       2.014  37.571  48.402  1.00 19.35           N  
+ATOM   2062  CA  SER A 262       2.487  38.181  49.569  1.00 10.16           C  
+ATOM   2063  C   SER A 262       1.519  39.313  49.915  1.00 27.74           C  
+ATOM   2064  O   SER A 262       0.650  39.654  49.105  1.00 33.05           O  
+ATOM   2065  CB  SER A 262       3.854  38.744  49.328  1.00  8.17           C  
+ATOM   2066  OG  SER A 262       3.732  40.019  48.725  1.00 80.68           O  
+ATOM   2067  N   SER A 263       1.670  39.914  51.100  1.00 38.35           N  
+ATOM   2068  CA  SER A 263       0.778  41.010  51.483  1.00 38.84           C  
+ATOM   2069  C   SER A 263       1.197  42.313  50.872  1.00 41.83           C  
+ATOM   2070  O   SER A 263       0.367  43.173  50.522  1.00 49.56           O  
+ATOM   2071  CB  SER A 263       0.542  41.124  52.991  1.00 47.75           C  
+ATOM   2072  OG  SER A 263      -0.499  40.218  53.400  1.00 71.46           O  
+ATOM   2073  N   ASP A 264       2.494  42.475  50.736  1.00 50.49           N  
+ATOM   2074  CA  ASP A 264       3.011  43.676  50.146  1.00 53.41           C  
+ATOM   2075  C   ASP A 264       2.867  43.642  48.623  1.00 48.29           C  
+ATOM   2076  O   ASP A 264       2.886  44.673  47.968  1.00 39.68           O  
+ATOM   2077  CB  ASP A 264       4.441  44.037  50.634  1.00 57.88           C  
+ATOM   2078  CG  ASP A 264       4.495  44.694  52.019  1.00 89.64           C  
+ATOM   2079  OD1 ASP A 264       3.662  45.527  52.436  1.00 89.94           O  
+ATOM   2080  OD2 ASP A 264       5.562  44.321  52.702  1.00 73.23           O  
+ATOM   2081  N   LEU A 265       2.672  42.423  48.089  1.00 40.13           N  
+ATOM   2082  CA  LEU A 265       2.394  42.225  46.680  1.00 37.60           C  
+ATOM   2083  C   LEU A 265       1.062  42.815  46.425  1.00 43.49           C  
+ATOM   2084  O   LEU A 265       0.894  43.712  45.630  1.00 70.01           O  
+ATOM   2085  CB  LEU A 265       2.299  40.717  46.348  1.00 47.37           C  
+ATOM   2086  CG  LEU A 265       2.988  40.265  45.051  1.00 47.79           C  
+ATOM   2087  CD1 LEU A 265       2.217  39.082  44.459  1.00 35.27           C  
+ATOM   2088  CD2 LEU A 265       3.102  41.402  44.031  1.00 22.65           C  
+ATOM   2089  N   LYS A 266       0.102  42.316  47.160  1.00 20.27           N  
+ATOM   2090  CA  LYS A 266      -1.243  42.792  47.051  1.00 16.18           C  
+ATOM   2091  C   LYS A 266      -1.354  44.262  47.349  1.00 35.71           C  
+ATOM   2092  O   LYS A 266      -2.365  44.870  47.054  1.00 46.14           O  
+ATOM   2093  CB  LYS A 266      -2.175  41.983  47.913  1.00 11.69           C  
+ATOM   2094  CG  LYS A 266      -1.921  40.490  47.736  1.00 44.59           C  
+ATOM   2095  CD  LYS A 266      -2.133  39.685  49.011  1.00 55.41           C  
+ATOM   2096  CE  LYS A 266      -3.554  39.170  49.188  1.00 88.00           C  
+ATOM   2097  NZ  LYS A 266      -3.676  37.719  48.966  1.00 37.50           N  
+ATOM   2098  N   ASP A 267      -0.305  44.847  47.961  1.00 51.17           N  
+ATOM   2099  CA  ASP A 267      -0.340  46.282  48.264  1.00 63.86           C  
+ATOM   2100  C   ASP A 267       0.025  47.106  47.057  1.00 51.22           C  
+ATOM   2101  O   ASP A 267      -0.751  47.947  46.585  1.00 43.63           O  
+ATOM   2102  CB  ASP A 267       0.521  46.684  49.468  1.00 74.78           C  
+ATOM   2103  CG  ASP A 267       0.006  47.948  50.124  1.00 78.81           C  
+ATOM   2104  OD1 ASP A 267      -1.136  48.045  50.545  1.00 36.76           O  
+ATOM   2105  OD2 ASP A 267       0.872  48.967  50.086  1.00 24.84           O  
+ATOM   2106  N   LEU A 268       1.216  46.840  46.567  1.00 47.17           N  
+ATOM   2107  CA  LEU A 268       1.708  47.448  45.386  1.00 19.73           C  
+ATOM   2108  C   LEU A 268       0.567  47.475  44.400  1.00 24.96           C  
+ATOM   2109  O   LEU A 268      -0.097  48.481  44.208  1.00 26.85           O  
+ATOM   2110  CB  LEU A 268       2.887  46.588  44.843  1.00 12.02           C  
+ATOM   2111  CG  LEU A 268       3.775  47.343  43.972  1.00 14.01           C  
+ATOM   2112  CD1 LEU A 268       3.624  48.756  44.352  1.00  4.99           C  
+ATOM   2113  CD2 LEU A 268       5.205  46.896  44.183  1.00 11.08           C  
+ATOM   2114  N   LEU A 269       0.209  46.282  43.970  1.00 14.61           N  
+ATOM   2115  CA  LEU A 269      -0.824  46.068  43.000  1.00 17.63           C  
+ATOM   2116  C   LEU A 269      -1.890  47.045  43.007  1.00 24.38           C  
+ATOM   2117  O   LEU A 269      -1.892  47.949  42.206  1.00 66.87           O  
+ATOM   2118  CB  LEU A 269      -1.362  44.644  42.939  1.00 11.73           C  
+ATOM   2119  CG  LEU A 269      -0.686  43.826  41.843  1.00 26.92           C  
+ATOM   2120  CD1 LEU A 269       0.663  44.473  41.477  1.00 24.20           C  
+ATOM   2121  CD2 LEU A 269      -0.452  42.383  42.302  1.00 22.43           C  
+ATOM   2122  N   ARG A 270      -2.841  46.831  43.834  1.00 18.75           N  
+ATOM   2123  CA  ARG A 270      -4.008  47.730  43.899  1.00 38.14           C  
+ATOM   2124  C   ARG A 270      -3.682  49.240  43.973  1.00 35.81           C  
+ATOM   2125  O   ARG A 270      -4.557  50.058  43.919  1.00 16.75           O  
+ATOM   2126  CB  ARG A 270      -5.024  47.288  44.903  1.00 29.92           C  
+ATOM   2127  CG  ARG A 270      -4.491  46.133  45.746  1.00100.00           C  
+ATOM   2128  CD  ARG A 270      -5.185  45.962  47.090  1.00100.00           C  
+ATOM   2129  NE  ARG A 270      -6.448  45.219  47.023  1.00 45.25           N  
+ATOM   2130  CZ  ARG A 270      -6.853  44.395  47.983  1.00 78.87           C  
+ATOM   2131  NH1 ARG A 270      -6.095  44.170  49.073  1.00 18.03           N  
+ATOM   2132  NH2 ARG A 270      -8.017  43.768  47.851  1.00 88.46           N  
+ATOM   2133  N   ASN A 271      -2.401  49.582  44.045  1.00 18.92           N  
+ATOM   2134  CA  ASN A 271      -1.992  50.958  43.968  1.00  5.60           C  
+ATOM   2135  C   ASN A 271      -1.760  51.347  42.506  1.00 41.03           C  
+ATOM   2136  O   ASN A 271      -2.197  52.433  42.029  1.00 33.53           O  
+ATOM   2137  CB  ASN A 271      -0.753  51.202  44.802  1.00 39.58           C  
+ATOM   2138  CG  ASN A 271      -1.119  51.774  46.123  1.00 53.07           C  
+ATOM   2139  OD1 ASN A 271      -1.113  52.983  46.280  1.00 51.95           O  
+ATOM   2140  ND2 ASN A 271      -1.656  50.937  46.996  1.00 30.04           N  
+ATOM   2141  N   LEU A 272      -1.093  50.413  41.776  1.00 26.75           N  
+ATOM   2142  CA  LEU A 272      -0.888  50.526  40.345  1.00 22.53           C  
+ATOM   2143  C   LEU A 272      -2.233  50.352  39.627  1.00 27.60           C  
+ATOM   2144  O   LEU A 272      -2.745  51.295  38.993  1.00 30.30           O  
+ATOM   2145  CB  LEU A 272       0.099  49.466  39.788  1.00 15.52           C  
+ATOM   2146  CG  LEU A 272       1.458  49.372  40.496  1.00 15.25           C  
+ATOM   2147  CD1 LEU A 272       2.089  47.996  40.188  1.00 12.27           C  
+ATOM   2148  CD2 LEU A 272       2.393  50.451  40.001  1.00 19.59           C  
+ATOM   2149  N   LEU A 273      -2.824  49.102  39.763  1.00 19.75           N  
+ATOM   2150  CA  LEU A 273      -4.131  48.753  39.165  1.00  8.59           C  
+ATOM   2151  C   LEU A 273      -5.251  49.635  39.672  1.00 12.16           C  
+ATOM   2152  O   LEU A 273      -6.345  49.171  40.041  1.00 15.35           O  
+ATOM   2153  CB  LEU A 273      -4.460  47.284  39.309  1.00 14.59           C  
+ATOM   2154  CG  LEU A 273      -3.479  46.378  38.572  1.00 25.11           C  
+ATOM   2155  CD1 LEU A 273      -2.183  46.304  39.333  1.00 41.00           C  
+ATOM   2156  CD2 LEU A 273      -4.068  44.977  38.455  1.00 28.99           C  
+ATOM   2157  N   GLN A 274      -4.937  50.924  39.707  1.00 34.31           N  
+ATOM   2158  CA  GLN A 274      -5.810  51.944  40.173  1.00 22.41           C  
+ATOM   2159  C   GLN A 274      -6.493  52.630  39.022  1.00 29.67           C  
+ATOM   2160  O   GLN A 274      -5.857  53.394  38.271  1.00 18.05           O  
+ATOM   2161  CB  GLN A 274      -5.050  52.970  41.033  1.00 14.51           C  
+ATOM   2162  CG  GLN A 274      -5.769  53.363  42.340  1.00 32.35           C  
+ATOM   2163  CD  GLN A 274      -7.290  53.180  42.336  1.00 83.46           C  
+ATOM   2164  OE1 GLN A 274      -8.023  54.088  42.725  1.00 38.61           O  
+ATOM   2165  NE2 GLN A 274      -7.759  51.938  42.102  1.00100.00           N  
+ATOM   2166  N   VAL A 275      -7.809  52.348  38.896  1.00 26.23           N  
+ATOM   2167  CA  VAL A 275      -8.680  52.896  37.840  1.00 17.85           C  
+ATOM   2168  C   VAL A 275      -8.765  54.432  37.856  1.00  7.71           C  
+ATOM   2169  O   VAL A 275      -9.406  55.072  37.001  1.00 47.65           O  
+ATOM   2170  CB  VAL A 275     -10.033  52.164  37.852  1.00 28.60           C  
+ATOM   2171  CG1 VAL A 275     -10.285  51.616  39.254  1.00 25.13           C  
+ATOM   2172  CG2 VAL A 275     -11.221  53.030  37.364  1.00 20.89           C  
+ATOM   2173  N   ASP A 276      -8.001  55.035  38.782  1.00 31.55           N  
+ATOM   2174  CA  ASP A 276      -7.916  56.488  38.886  1.00 15.87           C  
+ATOM   2175  C   ASP A 276      -6.500  56.951  38.814  1.00 29.03           C  
+ATOM   2176  O   ASP A 276      -5.641  56.645  39.699  1.00 18.94           O  
+ATOM   2177  CB  ASP A 276      -8.624  57.079  40.114  1.00  6.44           C  
+ATOM   2178  CG  ASP A 276      -8.606  58.613  40.123  1.00 54.97           C  
+ATOM   2179  OD1 ASP A 276      -7.606  59.277  39.852  1.00 43.27           O  
+ATOM   2180  OD2 ASP A 276      -9.770  59.147  40.485  1.00 25.76           O  
+ATOM   2181  N   LEU A 277      -6.238  57.710  37.765  1.00 17.95           N  
+ATOM   2182  CA  LEU A 277      -4.953  58.188  37.561  1.00 15.35           C  
+ATOM   2183  C   LEU A 277      -4.546  59.140  38.635  1.00 42.60           C  
+ATOM   2184  O   LEU A 277      -3.426  59.112  39.150  1.00 68.36           O  
+ATOM   2185  CB  LEU A 277      -4.654  58.645  36.109  1.00 21.06           C  
+ATOM   2186  CG  LEU A 277      -5.514  59.786  35.555  1.00 35.27           C  
+ATOM   2187  CD1 LEU A 277      -4.965  60.202  34.184  1.00 49.13           C  
+ATOM   2188  CD2 LEU A 277      -6.942  59.325  35.372  1.00 32.96           C  
+ATOM   2189  N   THR A 278      -5.482  59.873  39.073  1.00 22.98           N  
+ATOM   2190  CA  THR A 278      -5.234  60.782  40.108  1.00 21.07           C  
+ATOM   2191  C   THR A 278      -5.206  60.106  41.468  1.00 45.08           C  
+ATOM   2192  O   THR A 278      -5.763  60.601  42.447  1.00 68.54           O  
+ATOM   2193  CB  THR A 278      -6.189  61.987  40.030  1.00 69.17           C  
+ATOM   2194  OG1 THR A 278      -7.537  61.551  40.057  1.00 29.68           O  
+ATOM   2195  CG2 THR A 278      -5.926  62.767  38.729  1.00 41.93           C  
+ATOM   2196  N   LYS A 279      -4.529  58.971  41.502  1.00 45.88           N  
+ATOM   2197  CA  LYS A 279      -4.354  58.155  42.700  1.00 49.83           C  
+ATOM   2198  C   LYS A 279      -3.793  56.798  42.324  1.00 52.16           C  
+ATOM   2199  O   LYS A 279      -4.361  55.750  42.622  1.00 37.83           O  
+ATOM   2200  CB  LYS A 279      -5.625  58.027  43.514  1.00 34.36           C  
+ATOM   2201  CG  LYS A 279      -6.832  57.677  42.672  1.00100.00           C  
+ATOM   2202  CD  LYS A 279      -8.147  58.189  43.275  1.00100.00           C  
+ATOM   2203  CE  LYS A 279      -8.334  59.712  43.118  1.00100.00           C  
+ATOM   2204  NZ  LYS A 279      -9.701  60.181  43.449  1.00100.00           N  
+ATOM   2205  N   ARG A 280      -2.696  56.847  41.619  1.00 26.39           N  
+ATOM   2206  CA  ARG A 280      -2.076  55.691  41.123  1.00 24.22           C  
+ATOM   2207  C   ARG A 280      -0.607  55.865  41.163  1.00 18.57           C  
+ATOM   2208  O   ARG A 280      -0.089  56.754  40.533  1.00 20.88           O  
+ATOM   2209  CB  ARG A 280      -2.477  55.515  39.680  1.00 17.45           C  
+ATOM   2210  CG  ARG A 280      -1.636  54.433  38.994  1.00 38.27           C  
+ATOM   2211  CD  ARG A 280      -1.915  54.274  37.493  1.00 27.11           C  
+ATOM   2212  NE  ARG A 280      -3.320  54.051  37.163  1.00 15.79           N  
+ATOM   2213  CZ  ARG A 280      -3.799  54.181  35.938  1.00 38.41           C  
+ATOM   2214  NH1 ARG A 280      -3.005  54.526  34.908  1.00  2.73           N  
+ATOM   2215  NH2 ARG A 280      -5.113  54.001  35.740  1.00  1.42           N  
+ATOM   2216  N   PHE A 281       0.088  55.049  41.892  1.00  9.31           N  
+ATOM   2217  CA  PHE A 281       1.527  55.246  41.908  1.00 20.18           C  
+ATOM   2218  C   PHE A 281       1.961  55.467  40.556  1.00 12.53           C  
+ATOM   2219  O   PHE A 281       1.449  54.828  39.639  1.00 14.61           O  
+ATOM   2220  CB  PHE A 281       2.343  54.102  42.517  1.00 28.33           C  
+ATOM   2221  CG  PHE A 281       2.103  53.909  43.990  1.00 45.96           C  
+ATOM   2222  CD1 PHE A 281       1.514  54.916  44.762  1.00 41.79           C  
+ATOM   2223  CD2 PHE A 281       2.522  52.733  44.621  1.00 56.43           C  
+ATOM   2224  CE1 PHE A 281       1.278  54.735  46.125  1.00 26.26           C  
+ATOM   2225  CE2 PHE A 281       2.316  52.536  45.982  1.00 42.11           C  
+ATOM   2226  CZ  PHE A 281       1.682  53.539  46.722  1.00 44.41           C  
+ATOM   2227  N   GLY A 282       2.956  56.322  40.428  1.00 33.21           N  
+ATOM   2228  CA  GLY A 282       3.513  56.722  39.138  1.00 39.68           C  
+ATOM   2229  C   GLY A 282       2.953  58.090  38.691  1.00 40.05           C  
+ATOM   2230  O   GLY A 282       3.641  58.878  38.032  1.00 46.93           O  
+ATOM   2231  N   ASN A 283       1.707  58.353  39.117  1.00 18.33           N  
+ATOM   2232  CA  ASN A 283       0.969  59.562  38.796  1.00 44.12           C  
+ATOM   2233  C   ASN A 283       0.902  60.548  39.949  1.00 66.78           C  
+ATOM   2234  O   ASN A 283       0.466  61.702  39.792  1.00 71.90           O  
+ATOM   2235  CB  ASN A 283      -0.431  59.183  38.421  1.00 58.48           C  
+ATOM   2236  CG  ASN A 283      -0.892  59.919  37.252  1.00 24.07           C  
+ATOM   2237  OD1 ASN A 283      -0.172  60.801  36.721  1.00 72.40           O  
+ATOM   2238  ND2 ASN A 283      -2.090  59.598  36.838  1.00 34.27           N  
+ATOM   2239  N   LEU A 284       1.227  60.051  41.116  1.00 50.43           N  
+ATOM   2240  CA  LEU A 284       1.174  60.813  42.306  1.00 19.30           C  
+ATOM   2241  C   LEU A 284       2.289  61.810  42.388  1.00 35.74           C  
+ATOM   2242  O   LEU A 284       3.319  61.678  41.722  1.00 36.00           O  
+ATOM   2243  CB  LEU A 284       1.174  59.909  43.493  1.00 10.92           C  
+ATOM   2244  CG  LEU A 284      -0.213  59.562  43.960  1.00 14.89           C  
+ATOM   2245  CD1 LEU A 284      -1.181  59.513  42.785  1.00 41.90           C  
+ATOM   2246  CD2 LEU A 284      -0.186  58.219  44.642  1.00 31.80           C  
+ATOM   2247  N   LYS A 285       2.091  62.786  43.242  1.00 42.59           N  
+ATOM   2248  CA  LYS A 285       3.022  63.868  43.406  1.00 46.53           C  
+ATOM   2249  C   LYS A 285       4.446  63.470  43.783  1.00 45.42           C  
+ATOM   2250  O   LYS A 285       5.389  64.137  43.400  1.00 31.95           O  
+ATOM   2251  CB  LYS A 285       2.449  65.024  44.190  1.00 55.46           C  
+ATOM   2252  CG  LYS A 285       1.280  65.647  43.434  1.00100.00           C  
+ATOM   2253  CD  LYS A 285       1.480  65.584  41.909  1.00100.00           C  
+ATOM   2254  CE  LYS A 285       0.179  65.718  41.105  1.00100.00           C  
+ATOM   2255  NZ  LYS A 285       0.289  65.197  39.717  1.00100.00           N  
+ATOM   2256  N   ASN A 286       4.586  62.346  44.484  1.00 71.71           N  
+ATOM   2257  CA  ASN A 286       5.905  61.812  44.888  1.00 69.94           C  
+ATOM   2258  C   ASN A 286       6.554  61.045  43.700  1.00 75.77           C  
+ATOM   2259  O   ASN A 286       7.714  60.585  43.751  1.00 73.09           O  
+ATOM   2260  CB  ASN A 286       5.749  60.911  46.153  1.00 15.60           C  
+ATOM   2261  CG  ASN A 286       7.064  60.436  46.840  1.00100.00           C  
+ATOM   2262  OD1 ASN A 286       8.119  61.145  46.818  1.00 99.80           O  
+ATOM   2263  ND2 ASN A 286       6.981  59.260  47.528  1.00 60.51           N  
+ATOM   2264  N   GLY A 287       5.767  60.923  42.612  1.00 47.37           N  
+ATOM   2265  CA  GLY A 287       6.209  60.256  41.399  1.00 20.13           C  
+ATOM   2266  C   GLY A 287       6.551  58.786  41.610  1.00 29.67           C  
+ATOM   2267  O   GLY A 287       5.799  58.025  42.220  1.00 36.89           O  
+ATOM   2268  N   VAL A 288       7.692  58.401  41.063  1.00 41.38           N  
+ATOM   2269  CA  VAL A 288       8.177  57.041  41.110  1.00 45.96           C  
+ATOM   2270  C   VAL A 288       8.588  56.637  42.479  1.00 54.56           C  
+ATOM   2271  O   VAL A 288       8.769  55.433  42.779  1.00 46.03           O  
+ATOM   2272  CB  VAL A 288       9.371  56.866  40.185  1.00 53.57           C  
+ATOM   2273  CG1 VAL A 288       9.353  55.469  39.532  1.00 53.12           C  
+ATOM   2274  CG2 VAL A 288       9.381  57.961  39.143  1.00 50.30           C  
+ATOM   2275  N   ASN A 289       8.844  57.616  43.289  1.00 50.78           N  
+ATOM   2276  CA  ASN A 289       9.290  57.322  44.588  1.00 43.19           C  
+ATOM   2277  C   ASN A 289       8.224  56.650  45.402  1.00 32.04           C  
+ATOM   2278  O   ASN A 289       8.506  55.875  46.262  1.00 44.29           O  
+ATOM   2279  CB  ASN A 289      10.007  58.474  45.237  1.00 60.08           C  
+ATOM   2280  CG  ASN A 289      11.141  58.965  44.340  1.00 43.12           C  
+ATOM   2281  OD1 ASN A 289      12.217  58.337  44.262  1.00 39.13           O  
+ATOM   2282  ND2 ASN A 289      10.838  59.983  43.537  1.00 87.75           N  
+ATOM   2283  N   ASP A 290       6.983  56.815  44.981  1.00 25.18           N  
+ATOM   2284  CA  ASP A 290       5.898  56.090  45.591  1.00 22.90           C  
+ATOM   2285  C   ASP A 290       6.099  54.539  45.416  1.00 13.92           C  
+ATOM   2286  O   ASP A 290       5.924  53.728  46.354  1.00 33.29           O  
+ATOM   2287  CB  ASP A 290       4.561  56.492  44.965  1.00 33.21           C  
+ATOM   2288  CG  ASP A 290       4.037  57.858  45.327  1.00 51.68           C  
+ATOM   2289  OD1 ASP A 290       4.148  58.388  46.442  1.00 37.13           O  
+ATOM   2290  OD2 ASP A 290       3.311  58.355  44.351  1.00 58.45           O  
+ATOM   2291  N   ILE A 291       6.432  54.155  44.196  1.00 33.26           N  
+ATOM   2292  CA  ILE A 291       6.670  52.754  43.822  1.00 33.12           C  
+ATOM   2293  C   ILE A 291       8.006  52.344  44.306  1.00 34.26           C  
+ATOM   2294  O   ILE A 291       8.153  51.448  45.145  1.00 56.52           O  
+ATOM   2295  CB  ILE A 291       6.621  52.597  42.281  1.00 28.05           C  
+ATOM   2296  CG1 ILE A 291       5.220  52.883  41.749  1.00 19.29           C  
+ATOM   2297  CG2 ILE A 291       7.072  51.215  41.855  1.00 28.92           C  
+ATOM   2298  CD1 ILE A 291       5.232  53.667  40.446  1.00 36.19           C  
+ATOM   2299  N   LYS A 292       8.994  53.073  43.804  1.00 19.61           N  
+ATOM   2300  CA  LYS A 292      10.377  52.882  44.147  1.00 28.99           C  
+ATOM   2301  C   LYS A 292      10.569  52.624  45.645  1.00 31.42           C  
+ATOM   2302  O   LYS A 292      11.579  52.063  46.060  1.00 30.37           O  
+ATOM   2303  CB  LYS A 292      11.173  54.092  43.736  1.00 30.39           C  
+ATOM   2304  CG  LYS A 292      12.504  53.762  43.097  1.00  4.26           C  
+ATOM   2305  CD  LYS A 292      13.096  55.009  42.420  1.00 12.63           C  
+ATOM   2306  CE  LYS A 292      14.602  54.980  42.234  1.00 25.90           C  
+ATOM   2307  NZ  LYS A 292      15.160  56.326  42.017  1.00 49.12           N  
+ATOM   2308  N   ASN A 293       9.591  53.094  46.453  1.00 61.87           N  
+ATOM   2309  CA  ASN A 293       9.617  52.988  47.935  1.00 62.32           C  
+ATOM   2310  C   ASN A 293       8.628  51.971  48.484  1.00 43.05           C  
+ATOM   2311  O   ASN A 293       8.621  51.657  49.678  1.00 39.76           O  
+ATOM   2312  CB  ASN A 293       9.360  54.368  48.633  1.00 35.10           C  
+ATOM   2313  CG  ASN A 293      10.581  55.339  48.683  1.00100.00           C  
+ATOM   2314  OD1 ASN A 293      11.765  54.922  48.880  1.00 33.84           O  
+ATOM   2315  ND2 ASN A 293      10.274  56.653  48.615  1.00 11.48           N  
+ATOM   2316  N   HIS A 294       7.765  51.503  47.670  1.00 50.20           N  
+ATOM   2317  CA  HIS A 294       6.820  50.580  48.184  1.00 49.52           C  
+ATOM   2318  C   HIS A 294       7.483  49.336  48.806  1.00 62.00           C  
+ATOM   2319  O   HIS A 294       8.457  48.816  48.289  1.00 75.58           O  
+ATOM   2320  CB  HIS A 294       5.687  50.290  47.239  1.00 29.89           C  
+ATOM   2321  CG  HIS A 294       4.633  49.450  47.848  1.00 12.39           C  
+ATOM   2322  ND1 HIS A 294       4.829  48.080  48.036  1.00 22.90           N  
+ATOM   2323  CD2 HIS A 294       3.345  49.761  48.193  1.00  5.14           C  
+ATOM   2324  CE1 HIS A 294       3.671  47.607  48.484  1.00 34.31           C  
+ATOM   2325  NE2 HIS A 294       2.760  48.604  48.616  1.00 20.19           N  
+ATOM   2326  N   LYS A 295       6.983  48.948  49.987  1.00 55.61           N  
+ATOM   2327  CA  LYS A 295       7.553  47.871  50.762  1.00 34.86           C  
+ATOM   2328  C   LYS A 295       8.061  46.805  49.919  1.00 56.41           C  
+ATOM   2329  O   LYS A 295       9.228  46.430  50.000  1.00 94.63           O  
+ATOM   2330  CB  LYS A 295       6.624  47.316  51.846  1.00 38.11           C  
+ATOM   2331  CG  LYS A 295       6.003  48.394  52.725  1.00 61.98           C  
+ATOM   2332  CD  LYS A 295       4.997  49.269  51.972  1.00100.00           C  
+ATOM   2333  CE  LYS A 295       4.952  50.723  52.465  1.00100.00           C  
+ATOM   2334  NZ  LYS A 295       6.299  51.338  52.617  1.00 44.33           N  
+ATOM   2335  N   TRP A 296       7.221  46.315  49.082  1.00 34.33           N  
+ATOM   2336  CA  TRP A 296       7.618  45.229  48.242  1.00 34.31           C  
+ATOM   2337  C   TRP A 296       9.103  45.308  47.781  1.00 25.86           C  
+ATOM   2338  O   TRP A 296       9.785  44.299  47.612  1.00 26.03           O  
+ATOM   2339  CB  TRP A 296       6.693  45.109  47.101  1.00 32.40           C  
+ATOM   2340  CG  TRP A 296       6.638  43.747  46.618  1.00 39.39           C  
+ATOM   2341  CD1 TRP A 296       6.170  42.690  47.287  1.00 44.84           C  
+ATOM   2342  CD2 TRP A 296       7.037  43.280  45.346  1.00 41.67           C  
+ATOM   2343  NE1 TRP A 296       6.246  41.570  46.507  1.00 37.38           N  
+ATOM   2344  CE2 TRP A 296       6.763  41.912  45.307  1.00 43.41           C  
+ATOM   2345  CE3 TRP A 296       7.586  43.903  44.202  1.00 41.69           C  
+ATOM   2346  CZ2 TRP A 296       7.048  41.142  44.176  1.00 53.56           C  
+ATOM   2347  CZ3 TRP A 296       7.904  43.147  43.095  1.00 19.05           C  
+ATOM   2348  CH2 TRP A 296       7.619  41.787  43.074  1.00 30.54           C  
+ATOM   2349  N   PHE A 297       9.570  46.516  47.583  1.00 21.24           N  
+ATOM   2350  CA  PHE A 297      10.912  46.785  47.105  1.00 35.11           C  
+ATOM   2351  C   PHE A 297      11.877  46.976  48.229  1.00 47.04           C  
+ATOM   2352  O   PHE A 297      12.943  47.633  48.092  1.00 34.69           O  
+ATOM   2353  CB  PHE A 297      10.915  48.011  46.173  1.00 52.96           C  
+ATOM   2354  CG  PHE A 297      10.459  47.663  44.804  1.00 30.05           C  
+ATOM   2355  CD1 PHE A 297      11.278  46.893  43.983  1.00 34.38           C  
+ATOM   2356  CD2 PHE A 297       9.187  48.016  44.351  1.00 26.20           C  
+ATOM   2357  CE1 PHE A 297      10.874  46.542  42.699  1.00 38.51           C  
+ATOM   2358  CE2 PHE A 297       8.754  47.651  43.077  1.00 24.06           C  
+ATOM   2359  CZ  PHE A 297       9.598  46.904  42.259  1.00 18.87           C  
+ATOM   2360  N   ALA A 298      11.488  46.460  49.347  1.00 50.73           N  
+ATOM   2361  CA  ALA A 298      12.266  46.578  50.518  1.00 56.14           C  
+ATOM   2362  C   ALA A 298      13.698  46.148  50.282  1.00 40.11           C  
+ATOM   2363  O   ALA A 298      14.612  46.950  50.298  1.00 51.87           O  
+ATOM   2364  CB  ALA A 298      11.630  45.774  51.632  1.00 64.77           C  
+ATOM   2365  N   THR A 299      13.862  44.896  50.032  1.00 30.19           N  
+ATOM   2366  CA  THR A 299      15.154  44.310  49.823  1.00 34.52           C  
+ATOM   2367  C   THR A 299      15.922  44.896  48.628  1.00 54.15           C  
+ATOM   2368  O   THR A 299      17.130  45.048  48.679  1.00 61.78           O  
+ATOM   2369  CB  THR A 299      14.998  42.798  49.622  1.00 46.48           C  
+ATOM   2370  OG1 THR A 299      14.919  42.524  48.224  1.00 31.28           O  
+ATOM   2371  CG2 THR A 299      13.706  42.325  50.309  1.00 26.62           C  
+ATOM   2372  N   THR A 300      15.226  45.127  47.516  1.00 41.05           N  
+ATOM   2373  CA  THR A 300      15.886  45.535  46.294  1.00 27.79           C  
+ATOM   2374  C   THR A 300      16.801  46.696  46.428  1.00 20.62           C  
+ATOM   2375  O   THR A 300      16.354  47.784  46.750  1.00 41.90           O  
+ATOM   2376  CB  THR A 300      14.923  45.762  45.060  1.00 24.48           C  
+ATOM   2377  OG1 THR A 300      14.230  46.959  45.180  1.00 57.53           O  
+ATOM   2378  CG2 THR A 300      13.953  44.641  44.883  1.00 16.18           C  
+ATOM   2379  N   ASP A 301      18.081  46.496  45.984  1.00 23.78           N  
+ATOM   2380  CA  ASP A 301      19.045  47.608  45.868  1.00 17.64           C  
+ATOM   2381  C   ASP A 301      19.006  48.122  44.472  1.00 35.63           C  
+ATOM   2382  O   ASP A 301      19.545  47.507  43.581  1.00 40.00           O  
+ATOM   2383  CB  ASP A 301      20.525  47.267  46.281  1.00  9.76           C  
+ATOM   2384  CG  ASP A 301      21.524  48.349  45.863  1.00 58.76           C  
+ATOM   2385  OD1 ASP A 301      21.203  49.482  45.530  1.00 99.48           O  
+ATOM   2386  OD2 ASP A 301      22.759  47.922  45.849  1.00 96.69           O  
+ATOM   2387  N   TRP A 302      18.383  49.290  44.323  1.00 47.69           N  
+ATOM   2388  CA  TRP A 302      18.152  49.972  43.057  1.00 33.64           C  
+ATOM   2389  C   TRP A 302      19.408  50.248  42.164  1.00 38.52           C  
+ATOM   2390  O   TRP A 302      19.270  50.529  40.968  1.00 34.11           O  
+ATOM   2391  CB  TRP A 302      17.246  51.201  43.252  1.00 17.19           C  
+ATOM   2392  CG  TRP A 302      15.826  50.807  43.697  1.00 24.38           C  
+ATOM   2393  CD1 TRP A 302      15.311  50.980  44.908  1.00 23.15           C  
+ATOM   2394  CD2 TRP A 302      14.762  50.175  42.920  1.00 36.50           C  
+ATOM   2395  NE1 TRP A 302      14.011  50.548  44.969  1.00 24.80           N  
+ATOM   2396  CE2 TRP A 302      13.651  50.047  43.777  1.00 45.33           C  
+ATOM   2397  CE3 TRP A 302      14.630  49.755  41.604  1.00 30.38           C  
+ATOM   2398  CZ2 TRP A 302      12.435  49.538  43.341  1.00 47.36           C  
+ATOM   2399  CZ3 TRP A 302      13.444  49.206  41.192  1.00 30.98           C  
+ATOM   2400  CH2 TRP A 302      12.359  49.097  42.049  1.00 42.10           C  
+ATOM   2401  N   ILE A 303      20.628  50.119  42.730  1.00 36.69           N  
+ATOM   2402  CA  ILE A 303      21.855  50.322  41.930  1.00 44.63           C  
+ATOM   2403  C   ILE A 303      22.446  49.040  41.386  1.00 70.05           C  
+ATOM   2404  O   ILE A 303      22.717  48.943  40.207  1.00 84.20           O  
+ATOM   2405  CB  ILE A 303      22.908  51.138  42.604  1.00 44.05           C  
+ATOM   2406  CG1 ILE A 303      22.321  52.448  43.018  1.00 51.72           C  
+ATOM   2407  CG2 ILE A 303      24.040  51.378  41.631  1.00 35.09           C  
+ATOM   2408  CD1 ILE A 303      23.265  53.612  42.772  1.00 27.39           C  
+ATOM   2409  N   ALA A 304      22.690  48.065  42.255  1.00 48.10           N  
+ATOM   2410  CA  ALA A 304      23.207  46.812  41.781  1.00 41.59           C  
+ATOM   2411  C   ALA A 304      22.420  46.373  40.525  1.00 43.89           C  
+ATOM   2412  O   ALA A 304      23.002  46.216  39.453  1.00 34.22           O  
+ATOM   2413  CB  ALA A 304      23.199  45.746  42.881  1.00 40.12           C  
+ATOM   2414  N   ILE A 305      21.060  46.292  40.659  1.00 33.81           N  
+ATOM   2415  CA  ILE A 305      20.198  45.978  39.533  1.00 32.11           C  
+ATOM   2416  C   ILE A 305      20.676  46.787  38.372  1.00 52.86           C  
+ATOM   2417  O   ILE A 305      21.286  46.278  37.427  1.00 53.79           O  
+ATOM   2418  CB  ILE A 305      18.689  46.332  39.799  1.00 34.18           C  
+ATOM   2419  CG1 ILE A 305      17.902  45.180  40.463  1.00  1.00           C  
+ATOM   2420  CG2 ILE A 305      18.013  46.705  38.471  1.00 74.05           C  
+ATOM   2421  CD1 ILE A 305      18.139  45.054  41.953  1.00 59.34           C  
+ATOM   2422  N   TYR A 306      20.454  48.088  38.503  1.00 36.56           N  
+ATOM   2423  CA  TYR A 306      20.898  49.027  37.558  1.00 28.99           C  
+ATOM   2424  C   TYR A 306      22.315  48.681  37.087  1.00 42.30           C  
+ATOM   2425  O   TYR A 306      22.568  48.384  35.935  1.00 39.00           O  
+ATOM   2426  CB  TYR A 306      20.905  50.405  38.163  1.00 35.41           C  
+ATOM   2427  CG  TYR A 306      21.410  51.359  37.177  1.00 47.30           C  
+ATOM   2428  CD1 TYR A 306      22.781  51.561  37.008  1.00 56.89           C  
+ATOM   2429  CD2 TYR A 306      20.531  51.984  36.302  1.00 40.28           C  
+ATOM   2430  CE1 TYR A 306      23.275  52.390  36.009  1.00 51.43           C  
+ATOM   2431  CE2 TYR A 306      20.999  52.848  35.318  1.00 46.75           C  
+ATOM   2432  CZ  TYR A 306      22.373  53.043  35.174  1.00 54.37           C  
+ATOM   2433  OH  TYR A 306      22.839  53.855  34.198  1.00 72.16           O  
+ATOM   2434  N   GLN A 307      23.239  48.749  38.003  1.00 36.63           N  
+ATOM   2435  CA  GLN A 307      24.624  48.424  37.739  1.00 26.06           C  
+ATOM   2436  C   GLN A 307      24.777  46.996  37.278  1.00 29.99           C  
+ATOM   2437  O   GLN A 307      25.902  46.507  37.079  1.00 27.84           O  
+ATOM   2438  CB  GLN A 307      25.506  48.661  39.003  1.00 12.77           C  
+ATOM   2439  CG  GLN A 307      26.223  50.030  38.980  1.00 88.81           C  
+ATOM   2440  CD  GLN A 307      26.943  50.378  40.288  1.00 51.08           C  
+ATOM   2441  OE1 GLN A 307      27.361  51.547  40.495  1.00100.00           O  
+ATOM   2442  NE2 GLN A 307      27.101  49.374  41.143  1.00 99.64           N  
+ATOM   2443  N   ARG A 308      23.641  46.293  37.158  1.00 44.56           N  
+ATOM   2444  CA  ARG A 308      23.647  44.882  36.807  1.00 53.84           C  
+ATOM   2445  C   ARG A 308      24.731  44.154  37.547  1.00 46.06           C  
+ATOM   2446  O   ARG A 308      25.601  43.511  36.961  1.00 42.94           O  
+ATOM   2447  CB  ARG A 308      23.649  44.593  35.306  1.00 87.08           C  
+ATOM   2448  CG  ARG A 308      24.241  45.714  34.450  1.00100.00           C  
+ATOM   2449  CD  ARG A 308      24.535  45.289  32.994  1.00100.00           C  
+ATOM   2450  NE  ARG A 308      23.362  45.328  32.103  1.00 52.65           N  
+ATOM   2451  CZ  ARG A 308      22.817  44.258  31.513  1.00 66.57           C  
+ATOM   2452  NH1 ARG A 308      23.302  43.019  31.696  1.00 39.08           N  
+ATOM   2453  NH2 ARG A 308      21.755  44.437  30.703  1.00 24.81           N  
+ATOM   2454  N   LYS A 309      24.715  44.364  38.858  1.00 44.65           N  
+ATOM   2455  CA  LYS A 309      25.645  43.744  39.758  1.00 40.05           C  
+ATOM   2456  C   LYS A 309      24.988  42.626  40.502  1.00 40.67           C  
+ATOM   2457  O   LYS A 309      25.647  41.789  41.133  1.00 53.60           O  
+ATOM   2458  CB  LYS A 309      26.276  44.727  40.726  1.00 10.35           C  
+ATOM   2459  CG  LYS A 309      27.166  45.782  40.054  1.00 58.18           C  
+ATOM   2460  CD  LYS A 309      28.361  45.181  39.321  1.00100.00           C  
+ATOM   2461  CE  LYS A 309      29.456  46.196  39.031  1.00100.00           C  
+ATOM   2462  NZ  LYS A 309      29.992  46.833  40.248  1.00100.00           N  
+ATOM   2463  N   VAL A 310      23.689  42.601  40.424  1.00 22.95           N  
+ATOM   2464  CA  VAL A 310      22.951  41.583  41.100  1.00 34.10           C  
+ATOM   2465  C   VAL A 310      22.936  40.262  40.362  1.00 45.18           C  
+ATOM   2466  O   VAL A 310      22.923  40.201  39.141  1.00 60.21           O  
+ATOM   2467  CB  VAL A 310      21.548  42.028  41.473  1.00 52.64           C  
+ATOM   2468  CG1 VAL A 310      20.676  40.801  41.807  1.00 56.57           C  
+ATOM   2469  CG2 VAL A 310      21.603  42.987  42.666  1.00 52.12           C  
+ATOM   2470  N   GLU A 311      22.941  39.202  41.133  1.00 35.71           N  
+ATOM   2471  CA  GLU A 311      22.881  37.886  40.596  1.00 33.53           C  
+ATOM   2472  C   GLU A 311      21.484  37.525  40.264  1.00 33.38           C  
+ATOM   2473  O   GLU A 311      20.551  37.626  41.118  1.00 34.78           O  
+ATOM   2474  CB  GLU A 311      23.494  36.845  41.530  1.00 46.79           C  
+ATOM   2475  CG  GLU A 311      22.804  36.805  42.924  1.00100.00           C  
+ATOM   2476  CD  GLU A 311      23.740  36.388  44.049  1.00100.00           C  
+ATOM   2477  OE1 GLU A 311      24.308  35.306  44.088  1.00 75.88           O  
+ATOM   2478  OE2 GLU A 311      23.894  37.326  44.966  1.00100.00           O  
+ATOM   2479  N   ALA A 312      21.340  37.063  39.030  1.00 43.04           N  
+ATOM   2480  CA  ALA A 312      20.069  36.676  38.459  1.00 29.19           C  
+ATOM   2481  C   ALA A 312      19.460  35.350  38.964  1.00 43.12           C  
+ATOM   2482  O   ALA A 312      20.107  34.291  39.089  1.00 52.40           O  
+ATOM   2483  CB  ALA A 312      20.128  36.722  36.952  1.00 18.06           C  
+ATOM   2484  N   PRO A 313      18.197  35.436  39.160  1.00 33.07           N  
+ATOM   2485  CA  PRO A 313      17.346  34.353  39.545  1.00 29.48           C  
+ATOM   2486  C   PRO A 313      17.248  33.269  38.463  1.00 23.87           C  
+ATOM   2487  O   PRO A 313      17.049  32.093  38.751  1.00 48.81           O  
+ATOM   2488  CB  PRO A 313      15.962  34.985  39.628  1.00 23.14           C  
+ATOM   2489  CG  PRO A 313      16.036  36.325  38.932  1.00 20.49           C  
+ATOM   2490  CD  PRO A 313      17.478  36.666  38.824  1.00 18.27           C  
+ATOM   2491  N   PHE A 314      17.277  33.715  37.213  1.00 40.05           N  
+ATOM   2492  CA  PHE A 314      17.061  32.855  36.053  1.00 38.29           C  
+ATOM   2493  C   PHE A 314      18.113  32.953  34.986  1.00 29.19           C  
+ATOM   2494  O   PHE A 314      18.778  33.954  34.798  1.00 28.85           O  
+ATOM   2495  CB  PHE A 314      15.748  33.181  35.396  1.00 51.94           C  
+ATOM   2496  CG  PHE A 314      15.394  32.139  34.439  1.00 41.35           C  
+ATOM   2497  CD1 PHE A 314      15.111  30.869  34.910  1.00 44.08           C  
+ATOM   2498  CD2 PHE A 314      15.440  32.354  33.069  1.00 28.89           C  
+ATOM   2499  CE1 PHE A 314      14.803  29.827  34.047  1.00 47.40           C  
+ATOM   2500  CE2 PHE A 314      15.111  31.329  32.191  1.00 31.88           C  
+ATOM   2501  CZ  PHE A 314      14.822  30.059  32.683  1.00 32.69           C  
+ATOM   2502  N   ILE A 315      18.152  31.965  34.196  1.00 46.09           N  
+ATOM   2503  CA  ILE A 315      19.094  31.948  33.156  1.00 48.22           C  
+ATOM   2504  C   ILE A 315      18.650  31.042  32.017  1.00 80.21           C  
+ATOM   2505  O   ILE A 315      17.695  30.280  32.148  1.00100.00           O  
+ATOM   2506  CB  ILE A 315      20.417  31.535  33.727  1.00 27.51           C  
+ATOM   2507  CG1 ILE A 315      21.424  32.699  33.678  1.00 30.00           C  
+ATOM   2508  CG2 ILE A 315      20.921  30.268  33.064  1.00 26.51           C  
+ATOM   2509  CD1 ILE A 315      21.798  33.158  32.264  1.00 52.41           C  
+ATOM   2510  N   PRO A 316      19.325  31.140  30.894  1.00 43.40           N  
+ATOM   2511  CA  PRO A 316      19.007  30.288  29.788  1.00 34.19           C  
+ATOM   2512  C   PRO A 316      20.260  29.707  29.252  1.00 43.57           C  
+ATOM   2513  O   PRO A 316      21.351  30.227  29.476  1.00 15.51           O  
+ATOM   2514  CB  PRO A 316      18.333  31.136  28.740  1.00 40.94           C  
+ATOM   2515  CG  PRO A 316      18.455  32.592  29.202  1.00 56.77           C  
+ATOM   2516  CD  PRO A 316      19.051  32.569  30.596  1.00 44.92           C  
+ATOM   2517  N   LYS A 317      20.141  28.582  28.645  1.00 51.23           N  
+ATOM   2518  CA  LYS A 317      21.303  27.937  28.169  1.00 51.05           C  
+ATOM   2519  C   LYS A 317      21.516  28.156  26.726  1.00 91.62           C  
+ATOM   2520  O   LYS A 317      20.708  27.742  25.866  1.00100.00           O  
+ATOM   2521  CB  LYS A 317      21.336  26.478  28.510  1.00 71.98           C  
+ATOM   2522  CG  LYS A 317      22.711  25.876  28.316  1.00100.00           C  
+ATOM   2523  CD  LYS A 317      23.673  26.229  29.439  1.00100.00           C  
+ATOM   2524  CE  LYS A 317      24.934  25.368  29.437  1.00100.00           C  
+ATOM   2525  NZ  LYS A 317      25.760  25.533  28.215  1.00 80.23           N  
+ATOM   2526  N   PHE A 318      22.606  28.790  26.450  1.00 88.69           N  
+ATOM   2527  CA  PHE A 318      22.965  29.077  25.119  1.00 96.55           C  
+ATOM   2528  C   PHE A 318      24.026  28.119  24.676  1.00 74.77           C  
+ATOM   2529  O   PHE A 318      25.132  28.115  25.218  1.00 55.60           O  
+ATOM   2530  CB  PHE A 318      23.397  30.553  24.990  1.00100.00           C  
+ATOM   2531  CG  PHE A 318      23.056  31.323  26.256  1.00100.00           C  
+ATOM   2532  CD1 PHE A 318      23.927  31.279  27.349  1.00100.00           C  
+ATOM   2533  CD2 PHE A 318      21.833  31.999  26.410  1.00100.00           C  
+ATOM   2534  CE1 PHE A 318      23.623  31.928  28.554  1.00100.00           C  
+ATOM   2535  CE2 PHE A 318      21.509  32.658  27.608  1.00100.00           C  
+ATOM   2536  CZ  PHE A 318      22.425  32.646  28.670  1.00100.00           C  
+ATOM   2537  N   LYS A 319      23.646  27.234  23.761  1.00 78.29           N  
+ATOM   2538  CA  LYS A 319      24.556  26.249  23.254  1.00 82.93           C  
+ATOM   2539  C   LYS A 319      25.789  26.910  22.609  1.00 99.77           C  
+ATOM   2540  O   LYS A 319      26.921  26.401  22.695  1.00100.00           O  
+ATOM   2541  CB  LYS A 319      23.866  25.278  22.316  1.00 84.33           C  
+ATOM   2542  CG  LYS A 319      24.626  23.956  22.168  1.00100.00           C  
+ATOM   2543  CD  LYS A 319      24.124  23.093  20.992  1.00100.00           C  
+ATOM   2544  CE  LYS A 319      24.903  21.767  20.805  1.00100.00           C  
+ATOM   2545  NZ  LYS A 319      26.276  21.949  20.241  1.00100.00           N  
+ATOM   2546  N   GLY A 320      25.560  28.071  22.000  1.00 91.86           N  
+ATOM   2547  CA  GLY A 320      26.626  28.834  21.375  1.00 88.12           C  
+ATOM   2548  C   GLY A 320      26.143  30.203  20.851  1.00100.00           C  
+ATOM   2549  O   GLY A 320      24.954  30.602  21.027  1.00100.00           O  
+ATOM   2550  N   PRO A 321      27.085  30.919  20.195  1.00100.00           N  
+ATOM   2551  CA  PRO A 321      26.812  32.218  19.574  1.00100.00           C  
+ATOM   2552  C   PRO A 321      25.678  32.125  18.526  1.00100.00           C  
+ATOM   2553  O   PRO A 321      25.777  31.388  17.510  1.00100.00           O  
+ATOM   2554  CB  PRO A 321      28.126  32.644  18.887  1.00100.00           C  
+ATOM   2555  CG  PRO A 321      29.193  31.583  19.227  1.00100.00           C  
+ATOM   2556  CD  PRO A 321      28.526  30.531  20.102  1.00 93.40           C  
+ATOM   2557  N   GLY A 322      24.609  32.867  18.762  1.00 96.54           N  
+ATOM   2558  CA  GLY A 322      23.498  32.824  17.858  1.00 96.15           C  
+ATOM   2559  C   GLY A 322      22.763  31.486  17.937  1.00 86.92           C  
+ATOM   2560  O   GLY A 322      22.653  30.754  16.936  1.00 65.36           O  
+ATOM   2561  N   ASP A 323      22.323  31.151  19.168  1.00 68.91           N  
+ATOM   2562  CA  ASP A 323      21.541  29.984  19.419  1.00 63.65           C  
+ATOM   2563  C   ASP A 323      20.070  30.382  19.522  1.00 77.20           C  
+ATOM   2564  O   ASP A 323      19.684  31.177  20.385  1.00 68.40           O  
+ATOM   2565  CB  ASP A 323      22.023  29.211  20.656  1.00 55.70           C  
+ATOM   2566  CG  ASP A 323      21.323  27.895  20.808  1.00 65.65           C  
+ATOM   2567  OD1 ASP A 323      20.785  27.324  19.884  1.00 62.85           O  
+ATOM   2568  OD2 ASP A 323      21.308  27.484  22.053  1.00 61.76           O  
+ATOM   2569  N   THR A 324      19.274  29.897  18.563  1.00 89.33           N  
+ATOM   2570  CA  THR A 324      17.862  30.243  18.456  1.00 85.16           C  
+ATOM   2571  C   THR A 324      16.922  29.197  19.033  1.00 70.34           C  
+ATOM   2572  O   THR A 324      15.778  29.068  18.590  1.00 68.61           O  
+ATOM   2573  CB  THR A 324      17.469  30.579  17.005  1.00100.00           C  
+ATOM   2574  OG1 THR A 324      17.491  29.402  16.216  1.00 87.62           O  
+ATOM   2575  CG2 THR A 324      18.427  31.615  16.428  1.00 75.43           C  
+ATOM   2576  N   SER A 325      17.409  28.459  20.031  1.00 89.66           N  
+ATOM   2577  CA  SER A 325      16.625  27.402  20.705  1.00 95.59           C  
+ATOM   2578  C   SER A 325      15.488  27.984  21.504  1.00 85.62           C  
+ATOM   2579  O   SER A 325      14.338  27.480  21.496  1.00 75.80           O  
+ATOM   2580  CB  SER A 325      17.518  26.604  21.631  1.00 99.70           C  
+ATOM   2581  OG  SER A 325      18.321  27.498  22.406  1.00 60.82           O  
+ATOM   2582  N   ASN A 326      15.848  29.043  22.223  1.00 79.11           N  
+ATOM   2583  CA  ASN A 326      14.962  29.777  23.068  1.00 72.13           C  
+ATOM   2584  C   ASN A 326      13.854  30.445  22.269  1.00 73.20           C  
+ATOM   2585  O   ASN A 326      13.018  31.142  22.807  1.00 95.96           O  
+ATOM   2586  CB  ASN A 326      15.761  30.808  23.879  1.00 84.97           C  
+ATOM   2587  CG  ASN A 326      16.981  30.198  24.526  1.00 78.57           C  
+ATOM   2588  OD1 ASN A 326      16.863  29.440  25.487  1.00 20.77           O  
+ATOM   2589  ND2 ASN A 326      18.158  30.487  23.958  1.00 84.18           N  
+ATOM   2590  N   PHE A 327      13.857  30.201  20.985  1.00 65.54           N  
+ATOM   2591  CA  PHE A 327      12.910  30.787  20.116  1.00 58.56           C  
+ATOM   2592  C   PHE A 327      12.035  29.796  19.421  1.00 59.41           C  
+ATOM   2593  O   PHE A 327      12.271  28.580  19.421  1.00 59.13           O  
+ATOM   2594  CB  PHE A 327      13.558  31.765  19.126  1.00 48.44           C  
+ATOM   2595  CG  PHE A 327      14.213  32.955  19.817  1.00 37.04           C  
+ATOM   2596  CD1 PHE A 327      15.520  32.882  20.317  1.00 38.18           C  
+ATOM   2597  CD2 PHE A 327      13.516  34.151  19.979  1.00 33.37           C  
+ATOM   2598  CE1 PHE A 327      16.126  33.974  20.935  1.00 41.68           C  
+ATOM   2599  CE2 PHE A 327      14.102  35.262  20.587  1.00 45.72           C  
+ATOM   2600  CZ  PHE A 327      15.407  35.167  21.070  1.00 38.70           C  
+ATOM   2601  N   ASP A 328      11.002  30.331  18.838  1.00 63.87           N  
+ATOM   2602  CA  ASP A 328      10.015  29.628  18.113  1.00 76.11           C  
+ATOM   2603  C   ASP A 328      10.421  29.302  16.721  1.00 83.84           C  
+ATOM   2604  O   ASP A 328      11.467  29.755  16.229  1.00100.00           O  
+ATOM   2605  CB  ASP A 328       8.691  30.431  18.133  1.00 98.59           C  
+ATOM   2606  CG  ASP A 328       7.694  29.812  19.022  1.00100.00           C  
+ATOM   2607  OD1 ASP A 328       7.484  28.644  19.051  1.00100.00           O  
+ATOM   2608  OD2 ASP A 328       7.165  30.749  19.880  1.00100.00           O  
+ATOM   2609  N   ASP A 329       9.579  28.534  16.048  1.00 62.11           N  
+ATOM   2610  CA  ASP A 329       9.805  28.074  14.693  1.00 43.51           C  
+ATOM   2611  C   ASP A 329       8.781  28.612  13.782  1.00 61.42           C  
+ATOM   2612  O   ASP A 329       7.641  28.147  13.787  1.00 74.72           O  
+ATOM   2613  CB  ASP A 329       9.745  26.500  14.656  1.00 30.62           C  
+ATOM   2614  CG  ASP A 329      10.865  25.827  15.395  1.00 98.17           C  
+ATOM   2615  OD1 ASP A 329      12.010  26.176  15.340  1.00 79.15           O  
+ATOM   2616  OD2 ASP A 329      10.384  24.701  16.028  1.00 73.85           O  
+ATOM   2617  N   TYR A 330       9.121  29.588  12.985  1.00 50.16           N  
+ATOM   2618  CA  TYR A 330       8.156  30.081  12.065  1.00 46.42           C  
+ATOM   2619  C   TYR A 330       8.510  29.719  10.701  1.00 43.74           C  
+ATOM   2620  O   TYR A 330       9.644  29.289  10.451  1.00 56.30           O  
+ATOM   2621  CB  TYR A 330       7.946  31.579  12.176  1.00 63.87           C  
+ATOM   2622  CG  TYR A 330       7.873  32.091  13.586  1.00 60.24           C  
+ATOM   2623  CD1 TYR A 330       9.029  32.254  14.346  1.00 56.44           C  
+ATOM   2624  CD2 TYR A 330       6.657  32.486  14.140  1.00 54.84           C  
+ATOM   2625  CE1 TYR A 330       8.982  32.788  15.631  1.00 50.99           C  
+ATOM   2626  CE2 TYR A 330       6.583  33.008  15.431  1.00 22.51           C  
+ATOM   2627  CZ  TYR A 330       7.757  33.163  16.177  1.00 89.18           C  
+ATOM   2628  OH  TYR A 330       7.718  33.690  17.461  1.00 93.25           O  
+ATOM   2629  N   GLU A 331       7.539  29.907   9.790  1.00 46.81           N  
+ATOM   2630  CA  GLU A 331       7.733  29.610   8.379  1.00 39.65           C  
+ATOM   2631  C   GLU A 331       8.634  30.601   7.735  1.00 45.80           C  
+ATOM   2632  O   GLU A 331       8.504  31.771   7.986  1.00 65.75           O  
+ATOM   2633  CB  GLU A 331       6.437  29.601   7.647  1.00 38.81           C  
+ATOM   2634  CG  GLU A 331       6.566  28.844   6.337  1.00 68.13           C  
+ATOM   2635  CD  GLU A 331       5.628  29.320   5.299  1.00100.00           C  
+ATOM   2636  OE1 GLU A 331       4.519  29.815   5.798  1.00100.00           O  
+ATOM   2637  OE2 GLU A 331       5.886  29.273   4.117  1.00100.00           O  
+ATOM   2638  N   GLU A 332       9.543  30.134   6.863  1.00 32.84           N  
+ATOM   2639  CA  GLU A 332      10.490  31.055   6.201  1.00 27.11           C  
+ATOM   2640  C   GLU A 332       9.997  31.656   4.891  1.00 55.11           C  
+ATOM   2641  O   GLU A 332       9.249  31.043   4.121  1.00 45.44           O  
+ATOM   2642  CB  GLU A 332      11.923  30.527   6.099  1.00 24.67           C  
+ATOM   2643  CG  GLU A 332      12.509  30.033   7.473  1.00 67.15           C  
+ATOM   2644  CD  GLU A 332      13.135  31.125   8.369  1.00 28.38           C  
+ATOM   2645  OE1 GLU A 332      13.692  32.098   7.686  1.00 80.38           O  
+ATOM   2646  OE2 GLU A 332      13.239  31.018   9.588  1.00 54.53           O  
+ATOM   2647  N   GLU A 333      10.451  32.873   4.664  1.00 64.15           N  
+ATOM   2648  CA  GLU A 333      10.134  33.647   3.507  1.00 65.61           C  
+ATOM   2649  C   GLU A 333      11.387  34.326   2.997  1.00 56.98           C  
+ATOM   2650  O   GLU A 333      12.453  34.287   3.628  1.00 56.69           O  
+ATOM   2651  CB  GLU A 333       9.079  34.750   3.824  1.00 79.95           C  
+ATOM   2652  CG  GLU A 333       7.648  34.243   4.148  1.00 74.82           C  
+ATOM   2653  CD  GLU A 333       6.640  35.384   4.306  1.00 70.97           C  
+ATOM   2654  OE1 GLU A 333       6.946  36.588   4.286  1.00 60.32           O  
+ATOM   2655  OE2 GLU A 333       5.416  34.952   4.401  1.00 37.00           O  
+ATOM   2656  N   GLU A 334      11.229  35.011   1.894  1.00 50.18           N  
+ATOM   2657  CA  GLU A 334      12.292  35.727   1.294  1.00 37.43           C  
+ATOM   2658  C   GLU A 334      12.312  37.178   1.619  1.00 60.49           C  
+ATOM   2659  O   GLU A 334      11.315  37.776   2.027  1.00 84.34           O  
+ATOM   2660  CB  GLU A 334      12.314  35.553  -0.198  1.00 45.14           C  
+ATOM   2661  CG  GLU A 334      13.600  34.932  -0.655  1.00 91.69           C  
+ATOM   2662  CD  GLU A 334      13.439  34.264  -1.940  1.00 90.14           C  
+ATOM   2663  OE1 GLU A 334      12.446  33.617  -2.226  1.00 19.44           O  
+ATOM   2664  OE2 GLU A 334      14.444  34.474  -2.733  1.00 51.34           O  
+ATOM   2665  N   ILE A 335      13.452  37.757   1.345  1.00 64.79           N  
+ATOM   2666  CA  ILE A 335      13.675  39.144   1.538  1.00 64.33           C  
+ATOM   2667  C   ILE A 335      13.664  39.897   0.207  1.00 57.34           C  
+ATOM   2668  O   ILE A 335      14.699  40.403  -0.232  1.00 53.73           O  
+ATOM   2669  CB  ILE A 335      14.953  39.411   2.333  1.00 69.65           C  
+ATOM   2670  CG1 ILE A 335      15.260  38.223   3.275  1.00 74.72           C  
+ATOM   2671  CG2 ILE A 335      14.777  40.698   3.156  1.00 47.69           C  
+ATOM   2672  CD1 ILE A 335      15.846  36.991   2.563  1.00 91.50           C  
+ATOM   2673  N   ARG A 336      12.452  39.923  -0.426  1.00 48.27           N  
+ATOM   2674  CA  ARG A 336      12.136  40.602  -1.724  1.00 42.38           C  
+ATOM   2675  C   ARG A 336      12.697  42.090  -1.877  1.00 43.25           C  
+ATOM   2676  O   ARG A 336      12.668  42.866  -0.950  1.00 33.96           O  
+ATOM   2677  CB  ARG A 336      10.616  40.642  -1.918  1.00 31.06           C  
+ATOM   2678  CG  ARG A 336       9.986  39.298  -2.320  1.00 90.41           C  
+ATOM   2679  CD  ARG A 336       9.196  38.647  -1.187  1.00100.00           C  
+ATOM   2680  NE  ARG A 336       7.774  38.308  -1.524  1.00100.00           N  
+ATOM   2681  CZ  ARG A 336       7.253  38.030  -2.749  1.00100.00           C  
+ATOM   2682  NH1 ARG A 336       8.000  38.012  -3.880  1.00100.00           N  
+ATOM   2683  NH2 ARG A 336       5.926  37.741  -2.819  1.00 37.22           N  
+ATOM   2684  N   VAL A 337      13.045  42.500  -3.130  1.00 51.94           N  
+ATOM   2685  CA  VAL A 337      13.540  43.869  -3.372  1.00 54.96           C  
+ATOM   2686  C   VAL A 337      13.259  44.320  -4.812  1.00 41.49           C  
+ATOM   2687  O   VAL A 337      14.152  44.806  -5.518  1.00 48.79           O  
+ATOM   2688  CB  VAL A 337      15.043  44.023  -2.943  1.00 47.31           C  
+ATOM   2689  CG1 VAL A 337      15.626  45.394  -3.290  1.00 46.29           C  
+ATOM   2690  CG2 VAL A 337      15.254  43.844  -1.438  1.00 21.92           C  
+HETATM 2691  N   SEP A 338      11.982  44.356  -5.161  1.00 40.89           N  
+HETATM 2692  CA  SEP A 338      11.554  44.899  -6.464  1.00 44.12           C  
+HETATM 2693  CB  SEP A 338      10.350  45.824  -6.293  1.00 66.32           C  
+HETATM 2694  OG  SEP A 338       9.659  45.958  -7.528  1.00 42.96           O  
+HETATM 2695  C   SEP A 338      12.638  45.840  -7.001  1.00 63.35           C  
+HETATM 2696  O   SEP A 338      13.440  46.386  -6.237  1.00 98.19           O  
+HETATM 2697  P   SEP A 338       8.694  44.725  -7.713  1.00 88.95           P  
+HETATM 2698  O1P SEP A 338       7.767  45.005  -8.825  1.00 78.42           O  
+HETATM 2699  O2P SEP A 338       9.497  43.514  -8.014  1.00 74.87           O  
+HETATM 2700  O3P SEP A 338       7.933  44.519  -6.464  1.00100.00           O  
+ATOM   2701  N   ILE A 339      12.491  46.153  -8.263  1.00 51.32           N  
+ATOM   2702  CA  ILE A 339      13.588  46.614  -9.133  1.00 69.45           C  
+ATOM   2703  C   ILE A 339      13.624  48.167  -9.181  1.00 82.74           C  
+ATOM   2704  O   ILE A 339      14.653  48.816  -9.506  1.00 64.86           O  
+ATOM   2705  CB  ILE A 339      13.264  46.142 -10.542  1.00 85.75           C  
+ATOM   2706  CG1 ILE A 339      11.748  46.214 -10.827  1.00100.00           C  
+ATOM   2707  CG2 ILE A 339      13.681  44.682 -10.781  1.00 48.45           C  
+ATOM   2708  CD1 ILE A 339      11.257  45.147 -11.805  1.00100.00           C  
+ATOM   2709  N   ASN A 340      12.484  48.745  -8.750  1.00 80.28           N  
+ATOM   2710  CA  ASN A 340      12.286  50.180  -8.656  1.00 86.02           C  
+ATOM   2711  C   ASN A 340      11.910  50.630  -7.220  1.00 75.71           C  
+ATOM   2712  O   ASN A 340      11.174  49.945  -6.484  1.00 65.06           O  
+ATOM   2713  CB  ASN A 340      11.240  50.684  -9.680  1.00100.00           C  
+ATOM   2714  CG  ASN A 340      11.850  51.547 -10.794  1.00100.00           C  
+ATOM   2715  OD1 ASN A 340      12.556  52.571 -10.517  1.00100.00           O  
+ATOM   2716  ND2 ASN A 340      11.596  51.147 -12.053  1.00100.00           N  
+ATOM   2717  N   GLU A 341      12.434  51.780  -6.824  1.00 45.19           N  
+ATOM   2718  CA  GLU A 341      12.165  52.307  -5.514  1.00 21.90           C  
+ATOM   2719  C   GLU A 341      10.733  52.444  -5.234  1.00 34.04           C  
+ATOM   2720  O   GLU A 341      10.157  53.497  -5.440  1.00 41.14           O  
+ATOM   2721  CB  GLU A 341      12.833  53.643  -5.263  1.00 19.06           C  
+ATOM   2722  CG  GLU A 341      12.617  54.143  -3.830  1.00 65.59           C  
+ATOM   2723  CD  GLU A 341      12.427  55.617  -3.778  1.00100.00           C  
+ATOM   2724  OE1 GLU A 341      11.566  56.200  -4.434  1.00 49.36           O  
+ATOM   2725  OE2 GLU A 341      13.360  56.219  -3.053  1.00 31.88           O  
+ATOM   2726  N   LYS A 342      10.173  51.421  -4.675  1.00 54.59           N  
+ATOM   2727  CA  LYS A 342       8.814  51.455  -4.261  1.00 56.42           C  
+ATOM   2728  C   LYS A 342       8.686  52.319  -2.960  1.00 68.34           C  
+ATOM   2729  O   LYS A 342       9.601  52.316  -2.108  1.00 53.39           O  
+ATOM   2730  CB  LYS A 342       8.275  50.012  -4.120  1.00 50.31           C  
+ATOM   2731  CG  LYS A 342       7.235  49.818  -3.049  1.00 52.74           C  
+ATOM   2732  CD  LYS A 342       7.211  48.382  -2.507  1.00100.00           C  
+ATOM   2733  CE  LYS A 342       6.955  48.312  -0.992  1.00 81.41           C  
+ATOM   2734  NZ  LYS A 342       7.535  47.129  -0.353  1.00100.00           N  
+ATOM   2735  N   CYS A 343       7.615  53.169  -2.913  1.00 57.13           N  
+ATOM   2736  CA  CYS A 343       7.254  54.069  -1.753  1.00 47.83           C  
+ATOM   2737  C   CYS A 343       8.347  54.953  -1.124  1.00 54.17           C  
+ATOM   2738  O   CYS A 343       8.223  55.306   0.039  1.00 50.55           O  
+ATOM   2739  CB  CYS A 343       6.493  53.338  -0.650  1.00 42.02           C  
+ATOM   2740  SG  CYS A 343       4.787  53.144  -1.057  1.00 56.94           S  
+ATOM   2741  N   GLY A 344       9.354  55.375  -1.889  1.00 79.22           N  
+ATOM   2742  CA  GLY A 344      10.452  56.232  -1.334  1.00 86.81           C  
+ATOM   2743  C   GLY A 344      10.032  57.709  -0.990  1.00 76.52           C  
+ATOM   2744  O   GLY A 344      10.893  58.610  -0.727  1.00 44.98           O  
+ATOM   2745  N   LYS A 345       8.735  57.961  -0.986  1.00 61.61           N  
+ATOM   2746  CA  LYS A 345       8.258  59.297  -0.703  1.00 60.99           C  
+ATOM   2747  C   LYS A 345       8.141  59.569   0.769  1.00 59.30           C  
+ATOM   2748  O   LYS A 345       8.853  60.378   1.325  1.00 55.55           O  
+ATOM   2749  CB  LYS A 345       6.937  59.560  -1.383  1.00 63.01           C  
+ATOM   2750  CG  LYS A 345       6.987  60.776  -2.298  1.00100.00           C  
+ATOM   2751  CD  LYS A 345       6.554  62.081  -1.640  1.00100.00           C  
+ATOM   2752  CE  LYS A 345       6.673  63.292  -2.590  1.00100.00           C  
+ATOM   2753  NZ  LYS A 345       5.502  64.211  -2.559  1.00100.00           N  
+ATOM   2754  N   GLU A 346       7.215  58.874   1.367  1.00 50.69           N  
+ATOM   2755  CA  GLU A 346       6.883  59.005   2.740  1.00 56.81           C  
+ATOM   2756  C   GLU A 346       8.033  58.637   3.712  1.00 39.91           C  
+ATOM   2757  O   GLU A 346       7.974  58.930   4.890  1.00 47.95           O  
+ATOM   2758  CB  GLU A 346       5.592  58.205   3.031  1.00 60.70           C  
+ATOM   2759  CG  GLU A 346       4.438  58.522   2.014  1.00 55.62           C  
+ATOM   2760  CD  GLU A 346       4.642  57.964   0.594  1.00 97.27           C  
+ATOM   2761  OE1 GLU A 346       5.610  57.306   0.255  1.00 55.84           O  
+ATOM   2762  OE2 GLU A 346       3.653  58.271  -0.229  1.00 69.49           O  
+ATOM   2763  N   PHE A 347       9.075  58.032   3.211  1.00 35.19           N  
+ATOM   2764  CA  PHE A 347      10.146  57.605   4.082  1.00 32.35           C  
+ATOM   2765  C   PHE A 347      11.454  58.269   3.830  1.00 47.60           C  
+ATOM   2766  O   PHE A 347      12.487  57.621   3.876  1.00 49.40           O  
+ATOM   2767  CB  PHE A 347      10.329  56.093   4.048  1.00 26.18           C  
+ATOM   2768  CG  PHE A 347       9.034  55.327   4.262  1.00 35.05           C  
+ATOM   2769  CD1 PHE A 347       8.174  55.043   3.197  1.00 46.81           C  
+ATOM   2770  CD2 PHE A 347       8.710  54.834   5.523  1.00 17.39           C  
+ATOM   2771  CE1 PHE A 347       6.994  54.321   3.387  1.00 42.15           C  
+ATOM   2772  CE2 PHE A 347       7.530  54.127   5.735  1.00 31.11           C  
+ATOM   2773  CZ  PHE A 347       6.671  53.871   4.664  1.00 27.70           C  
+ATOM   2774  N   THR A 348      11.440  59.556   3.579  1.00 46.79           N  
+ATOM   2775  CA  THR A 348      12.696  60.247   3.336  1.00 48.22           C  
+ATOM   2776  C   THR A 348      13.515  60.363   4.589  1.00 61.33           C  
+ATOM   2777  O   THR A 348      14.747  60.510   4.519  1.00 60.03           O  
+ATOM   2778  CB  THR A 348      12.517  61.627   2.710  1.00 85.95           C  
+ATOM   2779  OG1 THR A 348      12.603  62.605   3.709  1.00 52.61           O  
+ATOM   2780  CG2 THR A 348      11.176  61.737   2.005  1.00100.00           C  
+ATOM   2781  N   GLU A 349      12.803  60.365   5.752  1.00 76.34           N  
+ATOM   2782  CA  GLU A 349      13.428  60.494   7.077  1.00 53.93           C  
+ATOM   2783  C   GLU A 349      14.181  59.251   7.487  1.00 40.40           C  
+ATOM   2784  O   GLU A 349      15.191  59.314   8.210  1.00 30.61           O  
+ATOM   2785  CB  GLU A 349      12.420  60.801   8.183  1.00 48.58           C  
+ATOM   2786  CG  GLU A 349      13.091  60.599   9.598  1.00100.00           C  
+ATOM   2787  CD  GLU A 349      12.293  59.752  10.605  1.00100.00           C  
+ATOM   2788  OE1 GLU A 349      11.163  60.054  10.989  1.00 86.87           O  
+ATOM   2789  OE2 GLU A 349      13.001  58.723  11.105  1.00 56.89           O  
+ATOM   2790  N   PHE A 350      13.631  58.112   7.104  1.00 32.56           N  
+ATOM   2791  CA  PHE A 350      14.203  56.878   7.483  1.00 26.71           C  
+ATOM   2792  C   PHE A 350      15.734  56.805   7.273  1.00 34.82           C  
+ATOM   2793  O   PHE A 350      16.468  56.585   8.255  1.00 58.24           O  
+ATOM   2794  CB  PHE A 350      13.466  55.668   6.935  1.00 15.01           C  
+ATOM   2795  CG  PHE A 350      13.783  54.479   7.768  1.00 20.81           C  
+ATOM   2796  CD1 PHE A 350      15.063  53.920   7.742  1.00 24.83           C  
+ATOM   2797  CD2 PHE A 350      12.861  53.990   8.692  1.00 25.14           C  
+ATOM   2798  CE1 PHE A 350      15.398  52.828   8.543  1.00 33.93           C  
+ATOM   2799  CE2 PHE A 350      13.183  52.905   9.515  1.00 46.70           C  
+ATOM   2800  CZ  PHE A 350      14.452  52.320   9.434  1.00 35.06           C  
+ATOM   2801  OXT PHE A 350      16.196  56.895   6.121  1.00 79.11           O  
+TER    2802      PHE A 350                                                      
+HETATM 2803  O5'   A A 351       8.480  41.650  18.848  1.00 32.82           O  
+HETATM 2804  C5'   A A 351       9.681  41.263  18.192  1.00 32.74           C  
+HETATM 2805  C4'   A A 351       9.958  39.792  18.377  1.00  6.65           C  
+HETATM 2806  O4'   A A 351      11.185  39.520  17.767  1.00 39.74           O  
+HETATM 2807  C3'   A A 351      10.107  39.327  19.856  1.00 83.94           C  
+HETATM 2808  O3'   A A 351       8.929  38.721  20.470  1.00 49.64           O  
+HETATM 2809  C2'   A A 351      11.191  38.315  19.784  1.00 10.81           C  
+HETATM 2810  O2'   A A 351      10.666  37.001  19.488  1.00 49.58           O  
+HETATM 2811  C1'   A A 351      12.028  38.840  18.634  1.00 41.61           C  
+HETATM 2812  N9    A A 351      13.015  39.753  18.990  1.00 10.03           N  
+HETATM 2813  C8    A A 351      12.811  41.128  18.863  1.00  3.26           C  
+HETATM 2814  N7    A A 351      13.938  41.847  19.088  1.00 17.34           N  
+HETATM 2815  C5    A A 351      14.930  40.849  19.306  1.00  1.00           C  
+HETATM 2816  C6    A A 351      16.321  40.918  19.586  1.00  8.93           C  
+HETATM 2817  N6    A A 351      16.990  42.073  19.730  1.00 15.70           N  
+HETATM 2818  N1    A A 351      16.993  39.737  19.764  1.00 20.44           N  
+HETATM 2819  C2    A A 351      16.320  38.564  19.603  1.00 20.99           C  
+HETATM 2820  N3    A A 351      15.012  38.368  19.330  1.00 23.27           N  
+HETATM 2821  C4    A A 351      14.366  39.556  19.206  1.00 11.01           C  
+HETATM 2822  O   HOH A 352      19.703  44.632  50.164  1.00 42.89           O  
+HETATM 2823  O   HOH A 353      19.766  55.057  38.698  1.00 48.60           O  
+HETATM 2824  O   HOH A 354       0.016  52.868  50.582  1.00 46.68           O  
+HETATM 2825  O   HOH A 355      21.563  48.972   2.000  1.00 35.61           O  
+HETATM 2826  O   HOH A 356      27.895  45.151  17.009  1.00 36.42           O  
+HETATM 2827  O   HOH A 357     -15.827  42.664  36.082  1.00 55.30           O  
+HETATM 2828  O   HOH A 358      19.092  53.561  46.593  1.00 59.98           O  
+HETATM 2829  O   HOH A 359      29.148  36.412  17.228  1.00 49.40           O  
+HETATM 2830  O   HOH A 360      18.004  55.527  37.268  1.00 35.92           O  
+HETATM 2831  O   HOH A 361      21.954  48.190  26.705  1.00 41.30           O  
+HETATM 2832  O   HOH A 362       9.725  32.787  19.980  1.00 41.55           O  
+HETATM 2833  O   HOH A 363      11.095  32.929  22.740  1.00 45.10           O  
+CONECT 1524 1536                                                                
+CONECT 1536 1524 1537                                                           
+CONECT 1537 1536 1538 1545                                                      
+CONECT 1538 1537 1539 1540                                                      
+CONECT 1539 1538                                                                
+CONECT 1540 1538 1541                                                           
+CONECT 1541 1540 1542 1543 1544                                                 
+CONECT 1542 1541                                                                
+CONECT 1543 1541                                                                
+CONECT 1544 1541                                                                
+CONECT 1545 1537 1546 1547                                                      
+CONECT 1546 1545                                                                
+CONECT 1547 1545                                                                
+CONECT 2686 2691                                                                
+CONECT 2691 2686 2692                                                           
+CONECT 2692 2691 2693 2695                                                      
+CONECT 2693 2692 2694                                                           
+CONECT 2694 2693 2697                                                           
+CONECT 2695 2692 2696 2701                                                      
+CONECT 2696 2695                                                                
+CONECT 2697 2694 2698 2699 2700                                                 
+CONECT 2698 2697                                                                
+CONECT 2699 2697                                                                
+CONECT 2700 2697                                                                
+CONECT 2701 2695                                                                
+MASTER      386    0    3   17    9    0    3    6 2832    1   25   27          
+END                                                                             

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1,0 +1,119 @@
+
+
+import os, sys
+import numpy as np
+import h5py
+import hdf5plugin
+
+from copy import deepcopy
+
+from zernikegrams import get_zernikegrams_from_pdbfile
+
+
+get_structural_info_kwargs__template = {'padded_length': None,
+                                'parser': 'biopython',
+                                'SASA': True,
+                                'charge': True,
+                                'DSSP': False,
+                                'angles': False,
+                                'fix': True,
+                                'hydrogens': True,
+                                'extra_molecules': True,
+                                'multi_struct': 'warn'}
+
+get_neighborhoods_kwargs__template = {'r_max': 10.0,
+                            'remove_central_residue': False,
+                            'remove_central_sidechain': True,
+                            'backbone_only': False,
+                            'get_residues': None}
+
+get_zernikegrams_kwargs__template = {'r_max': 10.0,
+                            'radial_func_mode': 'ks',
+                            'radial_func_max': 10,
+                            'Lmax': 5,
+                            'channels': ['C', 'N', 'O', 'S', 'H', 'SASA', 'charge'],
+                            'backbone_only': False,
+                            'request_frame': False,
+                            'get_physicochemical_info_for_hydrogens': True,
+                            'rst_normalization': 'square'}
+
+def test_get_zernikegrams_from_pdbfile():
+
+    '''
+    Interestingly, values sometimes slightly differ, though I don't think enough to cause problems (10^-3 or 10^-4).
+    I don't know what this is due to.
+    The amount and location of differences is different between biopython and pyrosetta parsing.
+    In both cases there seem to be regularities in which indices differ.
+    '''
+
+    os.system(f'structural-info \
+                    --hdf5_out sinfo.hdf5 \
+                    --pdb_dir ../data/pdbs \
+                    --parser biopython \
+                    --SASA \
+                    --charge \
+                    -F \
+                    -H ')
+    
+    os.system(f'neighborhoods \
+                    --hdf5_in  sinfo.hdf5 \
+                    --hdf5_out nbs.hdf5 \
+                    --remove_central_sidechain \
+                    --r_max 10.0')
+    
+    os.system(f'zernikegrams \
+                    --hdf5_in nbs.hdf5 \
+                    --hdf5_out zgrams.hdf5 \
+                    --rst_normalization square \
+                    --radial_func_max 10 \
+                    --l_max 5 \
+                    --radial_func_mode ks \
+                    --channels C,N,O,S,H,SASA,charge')
+    
+    pdbid = b'2fe3'
+
+    with h5py.File('zgrams.hdf5', 'r') as f:
+        res_ids_from_scripts = f['data']['res_id'][f['data']['res_id'][:, 1] == pdbid]
+        zgrams_from_scripts = f['data']['zernikegram'][f['data']['res_id'][:, 1] == pdbid]
+
+
+    data_from_pipeline = get_zernikegrams_from_pdbfile(f"../data/pdbs/{pdbid.decode('utf-8')}.pdb",
+                                                        get_structural_info_kwargs__template,
+                                                        get_neighborhoods_kwargs__template,
+                                                        get_zernikegrams_kwargs__template)
+    
+    res_ids_from_pipeline = data_from_pipeline['res_id']
+    zgrams_from_pipeline = data_from_pipeline['zernikegram']
+
+    print(np.all(res_ids_from_scripts == res_ids_from_pipeline))
+
+
+    for idx in range(res_ids_from_scripts.shape[0]):
+        print()
+        print(idx)
+        print(np.all(res_ids_from_scripts[idx] == res_ids_from_pipeline[idx]))
+        is_close = np.isclose(zgrams_from_scripts[idx], zgrams_from_pipeline[idx])
+        print(is_close.all())
+        print(np.sum(~is_close))
+        if not is_close.all():
+            print(zgrams_from_scripts[idx][~is_close])
+            print(zgrams_from_pipeline[idx][~is_close])
+            print(np.arange(len(is_close))[~is_close])
+        print()
+
+
+
+    os.remove('sinfo.hdf5')
+    os.remove('nbs.hdf5')
+    os.remove('zgrams.hdf5')
+
+
+
+
+
+
+if __name__ == '__main__':
+    test_get_zernikegrams_from_pdbfile()
+
+
+

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -48,7 +48,7 @@ def test_get_zernikegrams_from_pdbfile():
 
     os.system(f'structural-info \
                     --hdf5_out sinfo.hdf5 \
-                    --pdb_dir ../data/pdbs \
+                    --pdb_dir tests/data/pdbs \
                     --parser biopython \
                     --SASA \
                     --charge \
@@ -77,7 +77,7 @@ def test_get_zernikegrams_from_pdbfile():
         zgrams_from_scripts = f['data']['zernikegram'][f['data']['res_id'][:, 1] == pdbid]
 
 
-    data_from_pipeline = get_zernikegrams_from_pdbfile(f"../data/pdbs/{pdbid.decode('utf-8')}.pdb",
+    data_from_pipeline = get_zernikegrams_from_pdbfile(f"tests/data/pdbs/{pdbid.decode('utf-8')}.pdb",
                                                         get_structural_info_kwargs__template,
                                                         get_neighborhoods_kwargs__template,
                                                         get_zernikegrams_kwargs__template)

--- a/tests/struct_info/test_clean_pdb.py
+++ b/tests/struct_info/test_clean_pdb.py
@@ -23,7 +23,7 @@ def test_no_hydrogens_respected():
             tmp.name,
             "zernikegrams/structural_info/reduce/reduce/reduce_src/reduce",
             hydrogens=False,
-            ions=False
+            extra_molecules=False
         )
 
         assert count_element_atoms(tmp.name, "H") == 0
@@ -36,33 +36,33 @@ def test_yes_hydorgens_adds_H():
             tmp.name,
             "zernikegrams/structural_info/reduce/reduce/reduce_src/reduce",
             hydrogens=True,
-            ions=False
+            extra_molecules=False
         )
 
         assert count_element_atoms(tmp.name, "H") > 0
 
 
-def test_no_ions_removes_FE():
+def test_no_extra_molecules_removes_FE():
     with tempfile.NamedTemporaryFile() as tmp:
         clean_pdb(
             "tests/data/pdbs/1MBO.pdb",
             tmp.name,
             "zernikegrams/structural_info/reduce/reduce/reduce_src/reduce",
             hydrogens=False,
-            ions=False
+            extra_molecules=False
         )
 
         assert count_element_atoms(tmp.name, "FE") == 0
 
 
-def test_yes_ions_keeps_FE():
+def test_yes_extra_molecules_keeps_FE():
     with tempfile.NamedTemporaryFile() as tmp:
         clean_pdb(
             "tests/data/pdbs/1MBO.pdb",
             tmp.name,
             "zernikegrams/structural_info/reduce/reduce/reduce_src/reduce",
             hydrogens=False,
-            ions=True
+            extra_molecules=True
         )
 
         assert count_element_atoms(tmp.name, "FE") == 1 

--- a/tests/struct_info/test_pyrosetta_flag.py
+++ b/tests/struct_info/test_pyrosetta_flag.py
@@ -8,16 +8,15 @@ reference_path = "../data/baseline_struct_info._hdf5"
 
 def test_pyrosetta_flag():
 
-    os.system('structural-info --hdf5_out sinfo_pyrosetta_default.hdf5 --pdb_dir ../data/pdbs --parser biopython')
+    os.system('structural-info --hdf5_out sinfo_pyrosetta_default.hdf5 --pdb_dir ../data/pdbs --parser pyrosetta -F -H -S -c --DSSP')
     
     ref_pdb = b'2fe3'
 
     with h5py.File(reference_path) as ref:
-        print(len(ref['data']))
         for i in range(len(ref['data'])):
             if ref['data'][i]['pdb'] == ref_pdb:
                 true_mask = ref['data'][i]['atom_names'] != b''
-                print(f"number of atoms in ref: {np.sum(true_mask)}")
+                ref_num_atoms = np.sum(true_mask)
                 ref_res_ids = ref['data'][i]['res_ids'][true_mask]
                 ref_elements = ref['data'][i]['elements'][true_mask]
                 ref_atom_names = ref['data'][i]['atom_names'][true_mask]
@@ -25,15 +24,11 @@ def test_pyrosetta_flag():
                 ref_sasas = ref['data'][i]['SASAs'][true_mask]
                 ref_charges = ref['data'][i]['charges'][true_mask]
 
-                print(ref_res_ids)
-                print(ref_atom_names)
-
     with h5py.File('sinfo_pyrosetta_default.hdf5') as test:
-        print(len(test['data']))
         for i in range(len(test['data'])):
             if test['data'][i]['pdb'] == ref_pdb:
                 true_mask = test['data'][i]['atom_names'] != b''
-                print(f"number of atoms in new: {np.sum(true_mask)}")
+                test_num_atoms = np.sum(true_mask)
                 test_res_ids = test['data'][i]['res_ids'][true_mask]
                 test_elements = test['data'][i]['elements'][true_mask]
                 test_atom_names = test['data'][i]['atom_names'][true_mask]
@@ -41,9 +36,13 @@ def test_pyrosetta_flag():
                 test_sasas = test['data'][i]['SASAs'][true_mask]
                 test_charges = test['data'][i]['charges'][true_mask]
 
-                print(test_res_ids)
-                print(test_atom_names)
-    
+    assert ref_num_atoms == test_num_atoms
+    assert np.all(ref_res_ids == test_res_ids)
+    assert np.all(ref_elements == test_elements)
+    assert np.all(ref_atom_names == test_atom_names)
+
+    print('All tests passed!')
+
     os.remove('sinfo_pyrosetta_default.hdf5')
     
 

--- a/tests/struct_info/test_pyrosetta_flag.py
+++ b/tests/struct_info/test_pyrosetta_flag.py
@@ -4,11 +4,17 @@ import h5py
 import hdf5plugin
 import numpy as np
 
-reference_path = "../data/baseline_struct_info._hdf5"
+reference_path = "tests/data/baseline_struct_info._hdf5"
 
 def test_pyrosetta_flag():
 
-    os.system('structural-info --hdf5_out sinfo_pyrosetta_default.hdf5 --pdb_dir ../data/pdbs --parser pyrosetta -F -H -S -c --DSSP')
+    try:
+        import pyrosetta
+    except ModuleNotFoundError:
+        print("[warning] Cannot import pyrosetta -- skipping pyrosetta test")
+        return 
+
+    os.system('structural-info --hdf5_out sinfo_pyrosetta_default.hdf5 --pdb_dir tests/data/pdbs --parser pyrosetta -F -H -S -c --DSSP')
     
     ref_pdb = b'2fe3'
 

--- a/tests/struct_info/test_pyrosetta_flag.py
+++ b/tests/struct_info/test_pyrosetta_flag.py
@@ -1,0 +1,56 @@
+
+import os
+import h5py
+import hdf5plugin
+import numpy as np
+
+reference_path = "../data/baseline_struct_info._hdf5"
+
+def test_pyrosetta_flag():
+
+    os.system('structural-info --hdf5_out sinfo_pyrosetta_default.hdf5 --pdb_dir ../data/pdbs --parser biopython')
+    
+    ref_pdb = b'2fe3'
+
+    with h5py.File(reference_path) as ref:
+        print(len(ref['data']))
+        for i in range(len(ref['data'])):
+            if ref['data'][i]['pdb'] == ref_pdb:
+                true_mask = ref['data'][i]['atom_names'] != b''
+                print(f"number of atoms in ref: {np.sum(true_mask)}")
+                ref_res_ids = ref['data'][i]['res_ids'][true_mask]
+                ref_elements = ref['data'][i]['elements'][true_mask]
+                ref_atom_names = ref['data'][i]['atom_names'][true_mask]
+                ref_coords = ref['data'][i]['coords'][true_mask]
+                ref_sasas = ref['data'][i]['SASAs'][true_mask]
+                ref_charges = ref['data'][i]['charges'][true_mask]
+
+                print(ref_res_ids)
+                print(ref_atom_names)
+
+    with h5py.File('sinfo_pyrosetta_default.hdf5') as test:
+        print(len(test['data']))
+        for i in range(len(test['data'])):
+            if test['data'][i]['pdb'] == ref_pdb:
+                true_mask = test['data'][i]['atom_names'] != b''
+                print(f"number of atoms in new: {np.sum(true_mask)}")
+                test_res_ids = test['data'][i]['res_ids'][true_mask]
+                test_elements = test['data'][i]['elements'][true_mask]
+                test_atom_names = test['data'][i]['atom_names'][true_mask]
+                test_coords = test['data'][i]['coords'][true_mask]
+                test_sasas = test['data'][i]['SASAs'][true_mask]
+                test_charges = test['data'][i]['charges'][true_mask]
+
+                print(test_res_ids)
+                print(test_atom_names)
+    
+    os.remove('sinfo_pyrosetta_default.hdf5')
+    
+
+if __name__ == '__main__':
+    test_pyrosetta_flag()
+        
+                
+
+
+

--- a/zernikegrams/__init__.py
+++ b/zernikegrams/__init__.py
@@ -1,1 +1,2 @@
 from . import structural_info, neighborhoods, holograms, utils, add_noise
+from .pipeline import get_zernikegrams_from_pdbfile

--- a/zernikegrams/holograms/__init__.py
+++ b/zernikegrams/holograms/__init__.py
@@ -1,0 +1,1 @@
+from .get_holograms import get_holograms_fn

--- a/zernikegrams/holograms/get_holograms.py
+++ b/zernikegrams/holograms/get_holograms.py
@@ -122,7 +122,7 @@ def get_one_zernikegram(
     return hgm
 
 
-def get_zernikegrams(
+def get_holograms_fn(
     nbs: np.ndarray,  # of custom dtype
     r_max: float,
     radial_func_max: int,

--- a/zernikegrams/neighborhoods/__init__.py
+++ b/zernikegrams/neighborhoods/__init__.py
@@ -1,0 +1,1 @@
+from .get_neighborhoods import get_neighborhoods_fn

--- a/zernikegrams/neighborhoods/get_neighborhoods.py
+++ b/zernikegrams/neighborhoods/get_neighborhoods.py
@@ -24,7 +24,7 @@ from zernikegrams.utils import log_config as logging
 logger = logging.getLogger(__name__)
 
 
-def get_neighborhoods(
+def get_neighborhoods_fn(
     proteins: np.ndarray,
     r_max: float,
     remove_central_residue: bool = False,

--- a/zernikegrams/pipeline.py
+++ b/zernikegrams/pipeline.py
@@ -1,0 +1,23 @@
+
+from zernikegrams.structural_info import get_structural_info_fn
+from zernikegrams.neighborhoods import get_neighborhoods_fn
+from zernikegrams.holograms import get_holograms_fn
+
+from typing import *
+
+# @profile
+def get_zernikegrams_from_pdbfile(pdbfile: str,
+                                     get_structural_info_kwargs: Dict,
+                                     get_neighborhoods_kwargs: Dict,
+                                     get_zernikegrams_kwargs: Dict):
+
+    proteins = get_structural_info_fn(pdbfile, **get_structural_info_kwargs)
+    
+    neighborhoods = get_neighborhoods_fn(proteins, **get_neighborhoods_kwargs)
+
+    zernikegrams = get_holograms_fn(neighborhoods, **get_zernikegrams_kwargs)
+
+    return zernikegrams
+
+
+

--- a/zernikegrams/structural_info/RaSP.py
+++ b/zernikegrams/structural_info/RaSP.py
@@ -172,7 +172,7 @@ def _step_4_fix_numbering(fixer, temp3, temp4):
     return structure_after
 
 
-def clean_pdb(pdb_input_filename: str, out_path: str, reduce_executable: str, hydrogens: bool, ions: bool):
+def clean_pdb(pdb_input_filename: str, out_path: str, reduce_executable: str, hydrogens: bool, extra_molecules: bool):
     """
     Function to clean pdbs using reduce and pdbfixer.
 
@@ -186,8 +186,8 @@ def clean_pdb(pdb_input_filename: str, out_path: str, reduce_executable: str, hy
         Path to the reduce executable
     Hydrogens: bool
         include hydrogens
-    Ions: bool
-        include ions
+    extra_molecules: bool
+        include extra_molecules
     """
 
     pdbid = pdb_input_filename.split("/")[-1].split(".pdb")[0]
@@ -203,7 +203,7 @@ def clean_pdb(pdb_input_filename: str, out_path: str, reduce_executable: str, hy
 
         # Step 2: NonHetSelector filter
         with tempfile.NamedTemporaryFile(mode="wt", delete=True) as temp2:
-            if not ions:
+            if not extra_molecules:
                 PDBIO.set_structure(first_model)
                 PDBIO.save(temp2, select=NonHetSelector())
                 temp2.flush()

--- a/zernikegrams/structural_info/__init__.py
+++ b/zernikegrams/structural_info/__init__.py
@@ -1,1 +1,2 @@
 from . import get_structural_info, structural_info_core, RaSP
+from .get_structural_info import get_structural_info_fn

--- a/zernikegrams/structural_info/pyrosetta_core.py
+++ b/zernikegrams/structural_info/pyrosetta_core.py
@@ -1,0 +1,181 @@
+
+import numpy as np
+
+import numpy.typing as npt
+from typing import *
+
+import pyrosetta
+init_flags = '-ignore_unrecognized_res 1 -include_current -ex1 -ex2 -mute all -include_sugars -ignore_zero_occupancy false -obey_ENDMDL 1'
+pyrosetta.init(init_flags, silent=True)
+
+from pyrosetta.rosetta.core.pose import Pose
+from pyrosetta.rosetta.core.id import AtomID_Map_double_t, AtomID_Map_bool_t
+from pyrosetta.rosetta.core.scoring import calc_per_atom_sasa
+from pyrosetta.rosetta.utility import vector1_double
+
+import logging
+logger = logging.getLogger(__name__)
+
+from zernikegrams.structural_info.structural_info_core import get_chi_angles_and_norm_vecs, CHARGES_AMBER99SB
+
+
+def calculate_sasa(
+    pose : Pose,
+    probe_radius : float=1.4
+) -> AtomID_Map_double_t:
+    """Calculate SASA for a pose"""
+    # pyrosetta structures for returning of sasa information
+    all_atoms = AtomID_Map_bool_t()
+    atom_sasa = AtomID_Map_double_t()
+    rsd_sasa = vector1_double()
+    
+    # use pyrosetta to calculate SASA per atom
+    calc_per_atom_sasa(
+        pose,
+        atom_sasa,
+        rsd_sasa,
+        probe_radius
+    )
+    
+    return atom_sasa
+
+
+def get_structural_info_from_protein__pyrosetta(
+    pdb_file: str,
+    calculate_SASA: bool = True,
+    calculate_charge: bool = True,
+    calculate_DSSP: bool = True,
+    calculate_angles: bool = True,
+    # fix: bool = False,
+    # hydrogens: bool = False,
+    # extra_molecules: bool = True,
+    # multi_struct: str = "warn",
+    **kwargs
+ ) -> Tuple[str, Tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]]:
+    ## comment out these three lines for faster, bulk processing with pyrosetta, and uncomment the lines at the top of the script
+    # import pyrosetta
+    # init_flags = '-ignore_unrecognized_res 1 -include_current -ex1 -ex2 -mute all -include_sugars -ignore_zero_occupancy false -obey_ENDMDL 1'
+    # pyrosetta.init(init_flags, silent=True)
+
+    from pyrosetta.toolbox.extract_coords_pose import pose_coords_as_rows
+    from pyrosetta.rosetta.core.id import AtomID
+    from pyrosetta.rosetta.protocols.moves import DsspMover
+
+    pose = pyrosetta.pose_from_pdb(pdb_file)
+
+    # lists for each type of information to obtain
+    atom_names = []
+    elements = []
+    sasas = []
+    coords = []
+    charges_pyrosetta = []
+    res_ids = []
+
+    angles = []
+    vecs = []
+    res_ids_per_residue = []
+    
+    k = 0
+    
+    if calculate_DSSP:
+        # extract secondary structure for use in res ids
+        DSSP = DsspMover()
+        DSSP.apply(pose)
+    
+    if calculate_SASA:
+        # extract physico-chemical information
+        atom_sasa = calculate_sasa(pose)
+    
+    coords_rows = pose_coords_as_rows(pose)
+    
+    pi = pose.pdb_info()
+    pdb = pi.name().split('/')[-1][:-4] # remove .pdb extension
+    L = len(pdb)
+
+    logger.debug(f"pdb name in protein routine {pdb} - successfully loaded pdb into pyrosetta")
+
+    # get structural info from each residue in the protein
+    for i in range(1, pose.size()+1):
+        
+        # these data will form the residue id
+        aa = pose.sequence()[i-1]
+        chain = pi.chain(i)
+        resnum = str(pi.number(i)).encode()
+        icode = pi.icode(i).encode()
+        if calculate_DSSP:
+            ss = pose.secstruct(i)
+        else:
+            ss = None
+
+        if calculate_angles:
+            chis, norms = get_chi_angles_and_norm_vecs(pose.residue(i))
+            angles.append(chis)
+            vecs.append(norms)
+
+        res_id = np.array([
+                aa,
+                pdb,
+                chain,
+                resnum,
+                icode,
+                ss
+        ], dtype=f'S{L}')
+        res_ids_per_residue.append(res_id)
+        
+        for j in range(1,len(pose.residue(i).atoms())+1):
+
+            atom_name = pose.residue_type(i).atom_name(j)
+            idx = pose.residue(i).atom_index(atom_name)
+            atom_id = (AtomID(idx,i))
+            element = pose.residue_type(i).element(j).name
+            if calculate_SASA:
+                sasa = atom_sasa.get(atom_id)
+            curr_coords = coords_rows[k]
+            if calculate_charge:
+                charge_pyrosetta = pose.residue_type(i).atom_charge(j)
+
+            res_id = np.array([
+                aa,
+                pdb,
+                chain,
+                resnum,
+                icode,
+                ss
+            ], dtype=f'S{L}')
+            
+            atom_names.append(atom_name.strip().upper().ljust(4)) # adding this to make sure all atom names are 4 characters long, because for some atoms (the non-residue ones, and maybe others?) it is somehow not the case
+            elements.append(element)
+            res_ids.append(res_id)
+            coords.append(curr_coords)
+            sasas.append(sasa)
+            charges_pyrosetta.append(charge_pyrosetta)
+            
+            k += 1
+            
+    atom_names = np.array(atom_names,dtype='|S4')
+    elements = np.array(elements, dtype='S2')
+    sasas = np.array(sasas)
+    coords = np.array(coords)
+    charges_pyrosetta = np.array(charges_pyrosetta)
+    res_ids = np.array(res_ids)
+    
+    res_ids_per_residue = np.array(res_ids_per_residue)
+    angles = np.array(angles)
+    vecs = np.array(vecs)
+
+    # return pdb,(atom_names,elements,res_ids,coords,sasas,charges_pyrosetta,charges_amber99sb,res_ids_per_residue,angles_pyrosetta,angles,vecs)
+
+    return pdb, (
+        atom_names,
+        elements,
+        res_ids,
+        coords,
+        sasas,
+        charges_pyrosetta,
+        res_ids_per_residue,
+        angles,
+        vecs,
+        np.array(
+            [0] # just there for compatibility, assuming only one model in the file
+        ), 
+    )


### PR DESCRIPTION
Neat fact is that if you don't have pyrosetta installed, and only request to parse with biopython, the code will not try to import pyrosetta and thus not break